### PR TITLE
perf: réduction du coût CPU par frame de l'overlay typing et de la découverte nearby

### DIFF
--- a/UmbraSync/Services/AutoDetect/NearbyDiscoveryService.cs
+++ b/UmbraSync/Services/AutoDetect/NearbyDiscoveryService.cs
@@ -440,37 +440,39 @@ public class NearbyDiscoveryService(ILogger<NearbyDiscoveryService> logger, Mare
 
     private async Task<List<NearbyEntry>> GetLocalNearbyAsync()
     {
-        var list = new List<NearbyEntry>();
         try
         {
-            var local = await _dalamud.RunOnFrameworkThread(() => _dalamud.GetPlayerCharacter()).ConfigureAwait(false);
-            var localPos = local?.Position ?? Vector3.Zero;
-            int maxDist = MareConfig.AutoDetectFixedMaxDistanceMeters;
-
-            int limit = Math.Min(200, _objectTable.Length);
-            for (int i = 0; i < limit; i++)
+            return await _dalamud.RunOnFrameworkThread(() =>
             {
-                var objectIndex = i;
-                var obj = await _dalamud.RunOnFrameworkThread(() => _objectTable[objectIndex]).ConfigureAwait(false);
-                if (obj == null || obj.ObjectKind != Dalamud.Game.ClientState.Objects.Enums.ObjectKind.Pc) continue;
-                if (local != null && obj.Address == local.Address) continue;
+                var list = new List<NearbyEntry>();
+                var local = _dalamud.GetPlayerCharacter();
+                var localPos = local?.Position ?? Vector3.Zero;
+                int maxDist = MareConfig.AutoDetectFixedMaxDistanceMeters;
 
-                float dist = local == null ? float.NaN : Vector3.Distance(localPos, obj.Position);
-                if (!float.IsNaN(dist) && dist > maxDist) continue;
+                int limit = Math.Min(200, _objectTable.Length);
+                for (int i = 0; i < limit; i++)
+                {
+                    var obj = _objectTable[i];
+                    if (obj == null || obj.ObjectKind != Dalamud.Game.ClientState.Objects.Enums.ObjectKind.Pc) continue;
+                    if (local != null && obj.Address == local.Address) continue;
 
-                string name = obj.Name.TextValue;
-                ushort worldId = 0;
-                if (obj is Dalamud.Game.ClientState.Objects.SubKinds.IPlayerCharacter pc)
-                    worldId = (ushort)pc.HomeWorld.RowId;
+                    float dist = local == null ? float.NaN : Vector3.Distance(localPos, obj.Position);
+                    if (!float.IsNaN(dist) && dist > maxDist) continue;
 
-                list.Add(new NearbyEntry(name, worldId, dist, false, null, null, null));
-            }
+                    string name = obj.Name.TextValue;
+                    ushort worldId = 0;
+                    if (obj is Dalamud.Game.ClientState.Objects.SubKinds.IPlayerCharacter pc)
+                        worldId = (ushort)pc.HomeWorld.RowId;
+
+                    list.Add(new NearbyEntry(name, worldId, dist, false, null, null, null));
+                }
+                return list;
+            }).ConfigureAwait(false);
         }
         catch
         {
-            // ignore
+            return new List<NearbyEntry>();
         }
-        return list;
     }
     private async Task ImmediatePublishAsync(string publishEndpoint, byte[] saltBytes, CancellationToken ct)
     {

--- a/UmbraSync/UI/TypingIndicatorOverlay.cs
+++ b/UmbraSync/UI/TypingIndicatorOverlay.cs
@@ -177,6 +177,25 @@ public sealed class TypingIndicatorOverlay : WindowMediatorSubscriberBase
     private unsafe void DrawNameplateIndicators(ImDrawListPtr drawList, IReadOnlyDictionary<string, (UserData User, DateTime FirstSeen, DateTime LastUpdate)> activeTypers,
         bool selfActive, DateTime now, DateTime selfStart, DateTime selfLast)
     {
+        // si rien à dessiner, on évite la capture du depth buffer
+        bool willDrawSelf = selfActive
+            && _configService.Current.TypingIndicatorShowSelf
+            && _objectTable.LocalPlayer != null
+            && (now - selfStart) >= TypingDisplayDelay
+            && (now - selfLast) <= TypingDisplayFade;
+
+        bool hasOtherTypers = false;
+        foreach (var (uid, entry) in activeTypers)
+        {
+            if ((now - entry.LastUpdate) > TypingDisplayFade) continue;
+            if (string.Equals(uid, _apiController.UID, StringComparison.Ordinal)) continue;
+            hasOtherTypers = true;
+            break;
+        }
+
+        if (!willDrawSelf && !hasOtherTypers)
+            return;
+
         var iconWrap = _textureProvider.GetFromGameIcon(NameplateIconId).GetWrapOrEmpty();
         if (iconWrap.Handle == IntPtr.Zero)
             return;


### PR DESCRIPTION
## Résumé
Résout une chute de FPS jusqu'à -20 quand le plugin est actif.
                                                         
## Changements 
  - **`TypingIndicatorOverlay`** : early-out avant `OverlayEngine.BeginFrame` quand aucune bulle n'est à dessiner. Évite la capture du depth buffer (et le stall GPU associé) quand personne ne tape.
  - **`NearbyDiscoveryService.GetLocalNearbyAsync`** : itération de l'object table dans un unique `RunOnFrameworkThread` au lieu de jusqu'à 200 sauts par appel.
  - **`DepthBufferOcclusionStrategy`** : staging texture en double-buffer (ping-pong). `MapFlags` adaptés au backend (`DoNotWait` sur D3D11 natif, `None` sur DXVK qui retourne. Sinon un `DataBox` vide silencieusement).
## Mesures
  | Plateforme | `TypingIndicatorOverlay=>Draw` avg | FPS plugin actif |                                                                                                         
  |---|---|---|                                             
  | PC RTX 3060 (Win11/D3D11) | 5.75 ms → **0.02 ms** | 97 → **111** (+14) |                                                                                                       
  | Mac M4 Pro (XIVOnMac/DXVK) | 5.75 ms → **1.50 ms** | ~38 → **~45** (+7) |                                                                                                        

  Occlusion 3D conservée sur les deux plateformes.