### PR TITLE
fix: ajout d'une scrollbar dans l'annuaire

### DIFF
--- a/UmbraSync/UI/CompactUI.Annuaire.cs
+++ b/UmbraSync/UI/CompactUI.Annuaire.cs
@@ -264,9 +264,15 @@ public partial class CompactUi
             return;
         }
 
-        // Server-side ordering is applied in EstablishmentList (alphabetical by Name)
-        foreach (var e in _annuaireResults.Establishments)
-            DrawAnnuaireCard(e);
+        using (var scroll = ImRaii.Child("##annBrowseScroll", new Vector2(0, -ImGui.GetFrameHeightWithSpacing() - 4)))
+        {
+            if (scroll)
+            {
+                // Server-side ordering is applied in EstablishmentList (alphabetical by Name)
+                foreach (var e in _annuaireResults.Establishments)
+                    DrawAnnuaireCard(e);
+            }
+        }
 
         DrawAnnuairePagination();
     }
@@ -291,8 +297,12 @@ public partial class CompactUi
 
         if (_annuaireBookmarkResults != null)
         {
-            foreach (var establishment in _annuaireBookmarkResults.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase))
-                DrawAnnuaireCard(establishment);
+            using var scroll = ImRaii.Child("##annBookmarksScroll", new Vector2(0, 0));
+            if (scroll)
+            {
+                foreach (var establishment in _annuaireBookmarkResults.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase))
+                    DrawAnnuaireCard(establishment);
+            }
         }
     }
 
@@ -341,8 +351,12 @@ public partial class CompactUi
             return;
         }
 
-        foreach (var e in _annuaireOwned.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase))
-            DrawAnnuaireCard(e);
+        using var scroll = ImRaii.Child("##annOwnedScroll", new Vector2(0, 0));
+        if (scroll)
+        {
+            foreach (var e in _annuaireOwned.OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase))
+                DrawAnnuaireCard(e);
+        }
     }
 
     private void DrawAnnuaireCard(EstablishmentDto establishment)
@@ -599,6 +613,9 @@ public partial class CompactUi
             return;
         }
 
+        using var scroll = ImRaii.Child("##annUpcomingScroll", new Vector2(0, 0));
+        if (!scroll) return;
+
         if (tonightEvents.Count > 0)
         {
             using (ImRaii.PushFont(UiBuilder.IconFont))
@@ -706,8 +723,14 @@ public partial class CompactUi
             return;
         }
 
-        foreach (var announcement in _annuaireWildRpResults.Announcements)
-            DrawAnnuaireWildRpCard(announcement);
+        using (var scroll = ImRaii.Child("##annWildRpScroll", new Vector2(0, -ImGui.GetFrameHeightWithSpacing() - 4)))
+        {
+            if (scroll)
+            {
+                foreach (var announcement in _annuaireWildRpResults.Announcements)
+                    DrawAnnuaireWildRpCard(announcement);
+            }
+        }
 
         if (_annuaireWildRpResults.Announcements.Count == 0) return;
         var totalPages = Math.Max(1, (_annuaireWildRpResults.TotalCount + _annuaireWildRpResults.PageSize - 1) / Math.Max(_annuaireWildRpResults.PageSize, 1));

--- a/UmbraSync/UI/EstablishmentDirectoryUi.cs
+++ b/UmbraSync/UI/EstablishmentDirectoryUi.cs
@@ -238,12 +238,14 @@ internal class EstablishmentDirectoryUi : WindowMediatorSubscriberBase
             return;
         }
 
-        using var child = ImRaii.Child("##browseList", new Vector2(0, -ImGui.GetFrameHeightWithSpacing() - 4));
-        if (child)
+        using (var child = ImRaii.Child("##browseList", new Vector2(0, -ImGui.GetFrameHeightWithSpacing() - 4)))
         {
-            foreach (var establishment in _currentResults.Establishments)
+            if (child)
             {
-                DrawEstablishmentCard(establishment);
+                foreach (var establishment in _currentResults.Establishments)
+                {
+                    DrawEstablishmentCard(establishment);
+                }
             }
         }
 
@@ -439,7 +441,8 @@ internal class EstablishmentDirectoryUi : WindowMediatorSubscriberBase
         var catIcon = catIndex >= 0 && catIndex < CategoryIcons.Length ? CategoryIcons[catIndex] : FontAwesomeIcon.QuestionCircle;
         var catName = catIndex >= 0 && catIndex < CategoryNames.Length ? CategoryNames[catIndex] : "?";
 
-        using (var card = ImRaii.Child($"##card_{establishment.Id}", new Vector2(ImGui.GetContentRegionAvail().X, 68), true))
+        using (var card = ImRaii.Child($"##card_{establishment.Id}", new Vector2(ImGui.GetContentRegionAvail().X, 68), true,
+            ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))
         {
             if (card)
             {
@@ -712,12 +715,14 @@ internal class EstablishmentDirectoryUi : WindowMediatorSubscriberBase
             return;
         }
 
-        using var child = ImRaii.Child("##wildRpList", new Vector2(0, -ImGui.GetFrameHeightWithSpacing() - 4));
-        if (child)
+        using (var child = ImRaii.Child("##wildRpList", new Vector2(0, -ImGui.GetFrameHeightWithSpacing() - 4)))
         {
-            foreach (var announcement in _wildRpResults.Announcements)
+            if (child)
             {
-                DrawWildRpCard(announcement);
+                foreach (var announcement in _wildRpResults.Announcements)
+                {
+                    DrawWildRpCard(announcement);
+                }
             }
         }
 


### PR DESCRIPTION
## Résumé                                                                                                                                                                      
Corrige l'impossibilité de scroller dans l'annuaire quand le contenu déborde de la fenêtre.

## Cause                                                                                                                                                                       
Deux bugs cumulés :                                                                                                                                                            
1. **`CompactUI.Annuaire.cs`** : le conteneur parent `social-body` a `NoScrollWithMouse | NoScrollbar` (volontaire pour la section Pairs qui gère son propre scroll). Mais l'annuaire n'avait aucun child scrollable interne, donc tout débordait silencieusement.
2. **`EstablishmentDirectoryUi.cs`** (fenêtre annuaire) : les cartes individuelles (`ImRaii.Child(..., border=true)`) interceptaient la molette sans la propager à la liste parente. Le pattern correct (`NoScrollbar | NoScrollWithMouse` sur les cartes) existait déjà dans `CompactUI.Annuaire.cs:373` mais avait été oublié ici. De plus, `using var` faisait que la pagination était dessinée *dans* le child scrollable au lieu d'être ancrée en bas.

## Changements
`UmbraSync/UI/CompactUI.Annuaire.cs`Ajout d'un `ImRaii.Child` scrollable dans chaque sous-onglet (Browse, Bookmarks, Owned, Upcoming, WildRpList). Sans flags explicites → scrollbar visible uniquement si overflow (comportement ImGui par défaut).                                                                                                                                              
`UmbraSync/UI/EstablishmentDirectoryUi.cs`
- `DrawBrowseTab` / `DrawWildRpListSection` : `using var` → `using (...) {}` pour sortir la pagination du child.
- `DrawEstablishmentCard` : ajout `NoScrollbar | NoScrollWithMouse` sur les cartes pour propager la molette.                                                                   
                