### PR TITLE
feat: auto-tune réseau en cas d'instabilité

### DIFF
--- a/UmbraSync/Localization/Strings.fr.resx
+++ b/UmbraSync/Localization/Strings.fr.resx
@@ -5040,6 +5040,24 @@ Note : Les armes ne s'afficheront pas correctement sauf si vous utilisez le m&#x
   <data name="Settings.Performance.StaggeredInitialLoad.Help" xml:space="preserve">
     <value>Si activé, étale dans le temps les requêtes initiales après la connexion (pairs, syncshells, membres) au lieu de les lancer toutes en parallèle. Ajoute environ 240 ms au temps de connexion mais réduit les coupures sur les connexions capricieuses. Forcé activé quand le « Mode connexion lente » est activé.</value>
   </data>
+  <data name="Settings.Performance.NetworkAutoTune" xml:space="preserve">
+    <value>Auto-ajuster en cas de réseau instable</value>
+  </data>
+  <data name="Settings.Performance.NetworkAutoTune.Help" xml:space="preserve">
+    <value>Si activé, le plugin détecte les boucles de déconnexion/reconnexion et bascule automatiquement en « Mode connexion lente » pour stabiliser la session. Le mode normal est retenté toutes les 24 h. Désactivez si vous préférez gérer manuellement les paramètres réseau. Sans effet sur un mode connexion lente activé manuellement.</value>
+  </data>
+  <data name="Network.AutoTune.Activated.Title" xml:space="preserve">
+    <value>Réseau instable détecté</value>
+  </data>
+  <data name="Network.AutoTune.Activated.Body" xml:space="preserve">
+    <value>Plusieurs reconnexions courtes ont été détectées. Activation automatique du mode connexion lente pour stabiliser la session. Vous pouvez désactiver ce comportement dans les paramètres (Performance ▸ Réseau).</value>
+  </data>
+  <data name="Network.AutoTune.Reverted.Title" xml:space="preserve">
+    <value>Test du mode normal</value>
+  </data>
+  <data name="Network.AutoTune.Reverted.Body" xml:space="preserve">
+    <value>24 h se sont écoulées depuis l'activation automatique du mode connexion lente. Retour temporaire en mode normal pour vérifier si la connexion s'est stabilisée. En cas d'instabilité, le mode lent sera réactivé automatiquement.</value>
+  </data>
   <data name="Settings.Advanced.CharaData" xml:space="preserve">
     <value>Données de personnage</value>
   </data>

--- a/UmbraSync/Localization/Strings.resx
+++ b/UmbraSync/Localization/Strings.resx
@@ -5130,6 +5130,24 @@ Note: Weapons will not be displayed correctly unless using the same job as the s
   <data name="Settings.Performance.StaggeredInitialLoad.Help" xml:space="preserve">
     <value>When enabled, spreads out the initial requests after connecting (pairs, syncshells, members) over time instead of firing them all in parallel. Adds about 240 ms to the connection time but reduces the chance of TCP RST disconnects on capricious networks. Forced ON when "Slow connection mode" is enabled.</value>
   </data>
+  <data name="Settings.Performance.NetworkAutoTune" xml:space="preserve">
+    <value>Auto-adjust on unstable network</value>
+  </data>
+  <data name="Settings.Performance.NetworkAutoTune.Help" xml:space="preserve">
+    <value>When enabled, the plugin detects disconnect/reconnect loops and automatically switches to "Slow connection mode" to stabilize the session. Normal mode is retried every 24h. Disable if you prefer to manage network settings manually. Has no effect on a slow connection mode that was enabled manually.</value>
+  </data>
+  <data name="Network.AutoTune.Activated.Title" xml:space="preserve">
+    <value>Unstable network detected</value>
+  </data>
+  <data name="Network.AutoTune.Activated.Body" xml:space="preserve">
+    <value>Several short reconnections were detected. Slow connection mode has been enabled automatically to stabilize the session. You can disable this behavior in settings (Performance ▸ Network).</value>
+  </data>
+  <data name="Network.AutoTune.Reverted.Title" xml:space="preserve">
+    <value>Testing normal mode</value>
+  </data>
+  <data name="Network.AutoTune.Reverted.Body" xml:space="preserve">
+    <value>24h have passed since slow connection mode was auto-enabled. Temporarily reverting to normal mode to check whether the connection has stabilized. If unstable again, slow mode will be re-enabled automatically.</value>
+  </data>
   <data name="Settings.Advanced.CharaData" xml:space="preserve">
     <value>Character Data</value>
   </data>

--- a/UmbraSync/MareConfiguration/Configurations/MareConfig.cs
+++ b/UmbraSync/MareConfiguration/Configurations/MareConfig.cs
@@ -110,6 +110,9 @@ public class MareConfig : IMareConfiguration
     public bool UseInteractivePairRequestPopup { get; set; } = true;
     public bool SlowConnection { get; set; } = false;
     public bool StaggeredInitialLoad { get; set; } = false;
+    public bool NetworkAutoTune { get; set; } = true;
+    public bool SlowConnectionAutoEnabled { get; set; } = false;
+    public DateTime? SlowConnectionAutoEnabledAt { get; set; }
     public int TimeSpanBetweenScansInSeconds { get; set; } = 30;
     public int TransferBarsHeight { get; set; } = 12;
     public bool TransferBarsShowText { get; set; } = true;

--- a/UmbraSync/Plugin.cs
+++ b/UmbraSync/Plugin.cs
@@ -155,6 +155,7 @@ public sealed class Plugin : IDalamudPlugin
             collection.AddSingleton<IpcCallerMare>();
             collection.AddSingleton<IpcManager>();
             collection.AddSingleton<NotificationService>();
+            collection.AddSingleton<UmbraSync.Services.Network.NetworkAutoTuneService>();
             collection.AddSingleton<TemporarySyncshellNotificationService>();
             collection.AddSingleton<PartyListTypingService>();
             collection.AddSingleton<TypingIndicatorStateService>();
@@ -279,6 +280,7 @@ public sealed class Plugin : IDalamudPlugin
             collection.AddHostedService(p => p.GetRequiredService<ConfigurationSaveService>());
             collection.AddHostedService(p => p.GetRequiredService<MareMediator>());
             collection.AddHostedService(p => p.GetRequiredService<NotificationService>());
+            collection.AddHostedService(p => p.GetRequiredService<UmbraSync.Services.Network.NetworkAutoTuneService>());
             collection.AddHostedService(p => p.GetRequiredService<TemporarySyncshellNotificationService>());
             collection.AddSingleton<UmbraSync.Services.AutoDetect.PermanentSyncshellAutoDetectMonitor>();
             collection.AddHostedService(p => p.GetRequiredService<FileCacheManager>());

--- a/UmbraSync/Services/Network/NetworkAutoTuneService.cs
+++ b/UmbraSync/Services/Network/NetworkAutoTuneService.cs
@@ -1,0 +1,175 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using UmbraSync.Localization;
+using UmbraSync.MareConfiguration;
+using UmbraSync.MareConfiguration.Models;
+using UmbraSync.Services.Mediator;
+using UmbraSync.WebAPI;
+
+namespace UmbraSync.Services.Network;
+
+public sealed class NetworkAutoTuneService : DisposableMediatorSubscriberBase, IHostedService
+{
+    private const int ShortSessionThresholdSeconds = 60;
+    private const int WindowSeconds = 180;
+    private const int TriggerThreshold = 3;
+    private static readonly TimeSpan RetryAfter = TimeSpan.FromHours(24);
+    private static readonly TimeSpan RevertCheckInterval = TimeSpan.FromHours(1);
+    private static readonly TimeSpan GracePeriodAfterLogin = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan GracePeriodAtStartup = TimeSpan.FromSeconds(90);
+
+    private readonly MareConfigService _configService;
+    private readonly ApiController _apiController;
+    private readonly Queue<DateTime> _shortSessions = new();
+    private readonly Lock _lock = new();
+
+    private DateTime? _lastConnectedAt;
+    private DateTime _gracePeriodEnd;
+    private Timer? _revertTimer;
+
+    public NetworkAutoTuneService(ILogger<NetworkAutoTuneService> logger, MareMediator mediator,
+        MareConfigService configService, ApiController apiController) : base(logger, mediator)
+    {
+        _configService = configService;
+        _apiController = apiController;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _gracePeriodEnd = DateTime.UtcNow + GracePeriodAtStartup;
+
+        Mediator.Subscribe<HubReconnectedMessage>(this, _ => OnHubReconnected());
+        Mediator.Subscribe<HubReconnectingMessage>(this, _ => OnHubLost());
+        Mediator.Subscribe<HubClosedMessage>(this, _ => OnHubLost());
+        Mediator.Subscribe<DalamudLoginMessage>(this, _ => OnLogin());
+
+        _revertTimer = new Timer(_ => SafeCheckRevert(), null, RevertCheckInterval, RevertCheckInterval);
+        return Task.CompletedTask;
+    }
+
+    private void OnLogin()
+    {
+        lock (_lock)
+        {
+            _gracePeriodEnd = DateTime.UtcNow + GracePeriodAfterLogin;
+            _shortSessions.Clear();
+            _lastConnectedAt = null;
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _revertTimer?.Dispose();
+        _revertTimer = null;
+        return Task.CompletedTask;
+    }
+
+    private void OnHubReconnected()
+    {
+        lock (_lock)
+        {
+            _lastConnectedAt = DateTime.UtcNow;
+        }
+    }
+
+    private void OnHubLost()
+    {
+        lock (_lock)
+        {
+            var now = DateTime.UtcNow;
+
+            if (now < _gracePeriodEnd)
+            {
+                Logger.LogDebug("NetworkAutoTune: in grace period, ignoring hub-lost event");
+                _lastConnectedAt = null;
+                return;
+            }
+
+            if (_lastConnectedAt is { } connectedAt
+                && (now - connectedAt).TotalSeconds < ShortSessionThresholdSeconds)
+            {
+                _shortSessions.Enqueue(now);
+
+                var cutoff = now - TimeSpan.FromSeconds(WindowSeconds);
+                while (_shortSessions.Count > 0 && _shortSessions.Peek() < cutoff)
+                    _shortSessions.Dequeue();
+
+                Logger.LogDebug("NetworkAutoTune: short session detected ({count}/{threshold} in {window}s window)",
+                    _shortSessions.Count, TriggerThreshold, WindowSeconds);
+
+                if (_shortSessions.Count >= TriggerThreshold)
+                {
+                    TryActivateAutoTune();
+                }
+            }
+
+            _lastConnectedAt = null;
+        }
+    }
+
+    private void TryActivateAutoTune()
+    {
+        var cfg = _configService.Current;
+        if (!cfg.NetworkAutoTune || cfg.SlowConnection) return;
+
+        Logger.LogInformation("NetworkAutoTune: activating SlowConnection automatically (network instability detected)");
+
+        cfg.SlowConnection = true;
+        cfg.StaggeredInitialLoad = true;
+        cfg.SlowConnectionAutoEnabled = true;
+        cfg.SlowConnectionAutoEnabledAt = DateTime.UtcNow;
+        _configService.Save();
+
+        _shortSessions.Clear();
+
+        Mediator.Publish(new DualNotificationMessage(
+            Loc.Get("Network.AutoTune.Activated.Title"),
+            Loc.Get("Network.AutoTune.Activated.Body"),
+            NotificationType.Warning,
+            TimeSpan.FromSeconds(8)));
+
+        _ = _apiController.CreateConnections();
+    }
+
+    private void SafeCheckRevert()
+    {
+        try
+        {
+            CheckRevert();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "NetworkAutoTune: revert check failed");
+        }
+    }
+
+    private void CheckRevert()
+    {
+        var cfg = _configService.Current;
+        if (!cfg.SlowConnectionAutoEnabled) return;
+        if (cfg.SlowConnectionAutoEnabledAt is not { } enabledAt) return;
+        if (DateTime.UtcNow - enabledAt < RetryAfter) return;
+
+        Logger.LogInformation("NetworkAutoTune: 24h elapsed, reverting SlowConnection to retest network");
+
+        cfg.SlowConnection = false;
+        cfg.StaggeredInitialLoad = false;
+        cfg.SlowConnectionAutoEnabled = false;
+        cfg.SlowConnectionAutoEnabledAt = null;
+        _configService.Save();
+
+        lock (_lock)
+        {
+            _shortSessions.Clear();
+            _lastConnectedAt = null;
+        }
+
+        Mediator.Publish(new DualNotificationMessage(
+            Loc.Get("Network.AutoTune.Reverted.Title"),
+            Loc.Get("Network.AutoTune.Reverted.Body"),
+            NotificationType.Info,
+            TimeSpan.FromSeconds(6)));
+
+        _ = _apiController.CreateConnections();
+    }
+}

--- a/UmbraSync/UI/SettingsUi.cs
+++ b/UmbraSync/UI/SettingsUi.cs
@@ -2382,6 +2382,8 @@ public class SettingsUi : WindowMediatorSubscriberBase
         if (ImGui.Checkbox(Loc.Get("Settings.Performance.SlowConnection"), ref slowConnection))
         {
             _configService.Current.SlowConnection = slowConnection;
+            _configService.Current.SlowConnectionAutoEnabled = false;
+            _configService.Current.SlowConnectionAutoEnabledAt = null;
             _configService.Save();
             Mediator.Publish(new NotificationMessage(
                 Loc.Get("Settings.Performance.SlowConnection.RestartTitle"),
@@ -2402,6 +2404,14 @@ public class SettingsUi : WindowMediatorSubscriberBase
             }
             _uiShared.DrawHelpText(Loc.Get("Settings.Performance.StaggeredInitialLoad.Help"));
         }
+
+        bool networkAutoTune = _configService.Current.NetworkAutoTune;
+        if (ImGui.Checkbox(Loc.Get("Settings.Performance.NetworkAutoTune"), ref networkAutoTune))
+        {
+            _configService.Current.NetworkAutoTune = networkAutoTune;
+            _configService.Save();
+        }
+        _uiShared.DrawHelpText(Loc.Get("Settings.Performance.NetworkAutoTune.Help"));
 
         ImGui.Separator();
         _uiShared.BigText("Individual Limits");


### PR DESCRIPTION
## Résumé
Détecte automatiquement les boucles de déconnexion/reconnexion courtes et bascule sur le « Mode connexion lente » + « Étaler le chargement initial » sans intervention de l'utilisateur. Cible les nouveaux joueurs sur réseau capricieux qui ne savent pas qu'il faut activer ces options.
                                                                                                                                                                                                                                          
## Comportement
- **Détection** : 3 sessions courtes (`Reconnected → Closed/Reconnecting` en moins de 60 s) sur une fenêtre glissante de 180 s
- **Activation auto** : flip `SlowConnection` + `StaggeredInitialLoad`, reconnexion du hub, notification toast + chat (warning)
- **Réversibilité** : retest du mode normal toutes les 24 h ; si toujours instable, l'auto rebascule naturellement             
- **Anti faux positifs** :
    - Délai de grâce de 2 min après login + 90 s au démarrage du plugin (absorbe les déploiements serveur)                                                                                                                                                                                                                
    - Si l'utilisateur a activé `SlowConnection` manuellement, l'auto-tune n'y touche jamais                                                                                                                                                                                                                              
    - Nouvelle option `NetworkAutoTune` (par défaut ON, opt-out via *Paramètres ▸ Performance ▸ Réseau*)                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                          
## Fichiers touchés
                                                                                                                                                                                                                                                                                                                          
- `MareConfig.cs` — 3 nouveaux flags (`NetworkAutoTune`, `SlowConnectionAutoEnabled`, `SlowConnectionAutoEnabledAt`)
- `Services/Network/NetworkAutoTuneService.cs` — nouveau service hosted
- `Plugin.cs` — DI + hosted service
- `SettingsUi.cs` — checkbox + reset des flags `Auto*` lors d'un toggle manuel
- `Strings.fr.resx` + `Strings.resx` — 6 clés (UI + 2 notifications × 2 langues)