### PR TITLE
fix(core): optimisation gestion des paires (cache UID O(1)) + filet de sécurité reconnect

### DIFF
--- a/UmbraSync/PlayerData/Pairs/PairManager.cs
+++ b/UmbraSync/PlayerData/Pairs/PairManager.cs
@@ -23,6 +23,7 @@ namespace UmbraSync.PlayerData.Pairs;
 public sealed class PairManager : DisposableMediatorSubscriberBase
 {
     private readonly ConcurrentDictionary<UserData, Pair> _allClientPairs = new(UserDataComparer.Instance);
+    private readonly ConcurrentDictionary<string, Pair> _pairsByUid = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<GroupData, GroupFullInfoDto> _allGroups = new(GroupDataComparer.Instance);
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _pendingOffline = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, OnlineUserCharaDataDto> _pendingCharacterData = new(StringComparer.Ordinal);
@@ -87,7 +88,11 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
     public void AddGroupPair(GroupPairFullInfoDto dto, bool isInitialLoad = false)
     {
         if (!_allClientPairs.ContainsKey(dto.User))
-            _allClientPairs[dto.User] = _pairFactory.Create(dto.User);
+        {
+            var newPair = _pairFactory.Create(dto.User);
+            _allClientPairs[dto.User] = newPair;
+            _pairsByUid[dto.User.UID] = newPair;
+        }
 
         var pair = _allClientPairs[dto.User];
         var group = _allGroups[dto.Group];
@@ -113,13 +118,7 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
 
     public Pair? GetPairByUID(string uid)
     {
-        var existingPair = _allClientPairs.FirstOrDefault(f => uid.Equals(f.Key.UID, StringComparison.Ordinal));
-        if (!Equals(existingPair, default(KeyValuePair<UserData, Pair>)))
-        {
-            return existingPair.Value;
-        }
-
-        return null;
+        return _pairsByUid.TryGetValue(uid, out var pair) ? pair : null;
     }
 
     public bool IsAlreadyDirectPaired(string uid) => GetPairByUID(uid)?.UserPair != null;
@@ -128,7 +127,9 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
     {
         if (!_allClientPairs.ContainsKey(dto.User))
         {
-            _allClientPairs[dto.User] = _pairFactory.Create(dto.User);
+            var newPair = _pairFactory.Create(dto.User);
+            _allClientPairs[dto.User] = newPair;
+            _pairsByUid[dto.User.UID] = newPair;
         }
         else
         {
@@ -162,7 +163,9 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
     {
         if (!_allClientPairs.ContainsKey(dto.User))
         {
-            _allClientPairs[dto.User] = _pairFactory.Create(dto.User);
+            var newPair = _pairFactory.Create(dto.User);
+            _allClientPairs[dto.User] = newPair;
+            _pairsByUid[dto.User.UID] = newPair;
         }
 
         var pair = _allClientPairs[dto.User];
@@ -195,6 +198,7 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
         Logger.LogDebug("Clearing all Pairs");
         DisposePairs();
         _allClientPairs.Clear();
+        _pairsByUid.Clear();
         _allGroups.Clear();
         _pendingCharacterData.Clear();
         LastAddedUser = null;

--- a/UmbraSync/PlayerData/Pairs/PairManager.cs
+++ b/UmbraSync/PlayerData/Pairs/PairManager.cs
@@ -398,6 +398,7 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
 
             if (!_allClientPairs[item.Key].HasAnyConnection() && _allClientPairs.TryRemove(item.Key, out var pair))
             {
+                _pairsByUid.TryRemove(item.Key.UID, out _);
                 pair.MarkOffline();
             }
         }
@@ -416,6 +417,7 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
             {
                 pair.MarkOffline();
                 _allClientPairs.TryRemove(dto.User, out _);
+                _pairsByUid.TryRemove(dto.User.UID, out _);
             }
         }
 
@@ -432,6 +434,7 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
             {
                 pair.MarkOffline();
                 _allClientPairs.TryRemove(dto.User, out _);
+                _pairsByUid.TryRemove(dto.User.UID, out _);
             }
         }
 

--- a/UmbraSync/WebAPI/SignalR/ApiController.cs
+++ b/UmbraSync/WebAPI/SignalR/ApiController.cs
@@ -61,7 +61,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
         Mediator.Subscribe<DalamudLoginMessage>(this, (_) => DalamudUtilOnLogIn());
         Mediator.Subscribe<DalamudLogoutMessage>(this, (_) => DalamudUtilOnLogOut());
         Mediator.Subscribe<HubClosedMessage>(this, (msg) => MareHubOnClosed(msg.Exception));
-        Mediator.Subscribe<HubReconnectedMessage>(this, (msg) => _ = MareHubOnReconnected());
+        Mediator.Subscribe<HubReconnectedMessage>(this, (msg) => _ = SafeRunReconnected());
         Mediator.Subscribe<HubReconnectingMessage>(this, (msg) => MareHubOnReconnecting(msg.Exception));
 
         ServerState = ServerState.Offline;
@@ -425,6 +425,18 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
         else
         {
             Logger.LogInformation("Connection closed");
+        }
+    }
+    
+    private async Task SafeRunReconnected()
+    {
+        try
+        {
+            await MareHubOnReconnected().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unhandled exception escaped MareHubOnReconnected internal try/catch");
         }
     }
 


### PR DESCRIPTION
  ## Contexte                                                                                                                                                                                                                                
                                              
  Suite à l'audit approfondi client/serveur visant à aligner le projet sur les meilleures pratiques de robustesse et performance, deux quick wins :                                                                                          
  1. **Perf** : `GetPairByUID` faisait un LINQ `FirstOrDefault` O(n) sur la collection complète à chaque appel. Hot path : render loop, callbacks SignalR (`Client_UserSendOnline`, `Client_OnCharacterData`...), nameplates overlay.        
  2. **Robustesse** : le handler `HubReconnected` est subscribé en fire-and-forget (`_ = MareHubOnReconnected()`). Une exception levée avant le try/catch interne disparaissait silencieusement.                                             
                                                                                                                                                                                                                                             
  ## Changements                                                                                                                                                                                                                             
                                                            
  ### `PairManager.cs` Cache secondaire `_pairsByUid`                                                                                                                                                                                      
  - Ajout d'un `ConcurrentDictionary<string, Pair>` indexé par UID, maintenu en sync avec `_allClientPairs` à chaque mutation
  - 7 sites de mutation synchronisés (3 ADD, 1 CLEAR, 3 REMOVE)                                                                                                                                                                              
  - `GetPairByUID(string uid)` passe d'O(n) LINQ à O(1) `TryGetValue`                                                                                                                                                                        
                                              
  ### `ApiController.cs` Wrapper `SafeRunReconnected`                                                                                                                                                                                      
  - Wrapper try/catch autour de `MareHubOnReconnected()` pour garantir que toute exception échappant au try interne soit au moins loggée                                                                                                     
  - Le subscribe Mediator passe de `_ = MareHubOnReconnected()` à `_ = SafeRunReconnected()`                                                                                                                                                 
                                                                                                                                                                                                                                             
  ## Impact attendu                                                                                                                                                                                                                          
                                                                                                                                                                                                                                             
  - **Frame rate** plus stable pour les utilisateurs avec beaucoup de paires (>100), car `GetPairByUID` est appelé fréquemment depuis le render loop                                                                                         
  - **Visibilité accrue** sur les bugs de reconnexion (plus de disparition silencieuse)