### PR TITLE
fix(async): propagation des CancellationToken (uploads, downloads, décompression)

### DIFF
--- a/UmbraSync/WebAPI/Files/FileDownloadManager.cs
+++ b/UmbraSync/WebAPI/Files/FileDownloadManager.cs
@@ -1026,7 +1026,7 @@ public class FileDownloadManager : DisposableMediatorSubscriberBase
                     tasks.Add(Task.Run(async () =>
                     {
                         var gate = GetDecompressGate();
-                        await gate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+                        await gate.WaitAsync(ct).ConfigureAwait(false);
                         var hashSuccess = false;
                         try
                         {
@@ -1092,7 +1092,7 @@ public class FileDownloadManager : DisposableMediatorSubscriberBase
                             CompleteDownloadHash(capturedHash, hashSuccess);
                             pendingFallbackHashes.TryRemove(capturedHash, out _);
                         }
-                    }, CancellationToken.None));
+                    }, ct));
                 }
 
                 Task.WaitAll([.. tasks], CancellationToken.None);
@@ -1516,7 +1516,7 @@ public class FileDownloadManager : DisposableMediatorSubscriberBase
                     tasks.Add(Task.Run(async () =>
                     {
                         var gate = GetDecompressGate();
-                        await gate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+                        await gate.WaitAsync(ct).ConfigureAwait(false);
                         var hashSuccess = false;
                         try
                         {
@@ -1587,7 +1587,7 @@ public class FileDownloadManager : DisposableMediatorSubscriberBase
                             CompleteDownloadHash(capturedHash, hashSuccess);
                             pendingFallbackHashes.TryRemove(capturedHash, out _);
                         }
-                    }, CancellationToken.None));
+                    }, ct));
                 }
 
                 Task.WaitAll([.. tasks], CancellationToken.None);

--- a/UmbraSync/WebAPI/SignalR/ApiController.Functions.HousingShare.cs
+++ b/UmbraSync/WebAPI/SignalR/ApiController.Functions.HousingShare.cs
@@ -12,8 +12,9 @@ public sealed partial class ApiController
         if (!IsConnected) return;
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
-            await _mareHub!.InvokeAsync(nameof(HousingShareUpload), dto, cts.Token).ConfigureAwait(false);
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, _connectionCancellationTokenSource.Token);
+            await _mareHub!.InvokeAsync(nameof(HousingShareUpload), dto, linkedCts.Token).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -27,8 +28,9 @@ public sealed partial class ApiController
         if (!IsConnected) return null;
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
-            return await _mareHub!.InvokeAsync<HousingSharePayloadDto?>(nameof(HousingShareDownload), shareId, cts.Token).ConfigureAwait(false);
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, _connectionCancellationTokenSource.Token);
+            return await _mareHub!.InvokeAsync<HousingSharePayloadDto?>(nameof(HousingShareDownload), shareId, linkedCts.Token).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/UmbraSync/WebAPI/SignalR/ApiController.Functions.McdfShare.cs
+++ b/UmbraSync/WebAPI/SignalR/ApiController.Functions.McdfShare.cs
@@ -39,8 +39,9 @@ public sealed partial class ApiController
         if (!IsConnected) return;
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
-            await _mareHub!.InvokeAsync(nameof(McdfShareUpload), requestDto, cts.Token).ConfigureAwait(false);
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, _connectionCancellationTokenSource.Token);
+            await _mareHub!.InvokeAsync(nameof(McdfShareUpload), requestDto, linkedCts.Token).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -54,8 +55,9 @@ public sealed partial class ApiController
         if (!IsConnected) return null;
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
-            return await _mareHub!.InvokeAsync<McdfSharePayloadDto?>(nameof(McdfShareDownload), shareId, cts.Token).ConfigureAwait(false);
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(30));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, _connectionCancellationTokenSource.Token);
+            return await _mareHub!.InvokeAsync<McdfSharePayloadDto?>(nameof(McdfShareDownload), shareId, linkedCts.Token).ConfigureAwait(false);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Résumé

Propage proprement les \`CancellationToken\` dans deux chaînes async où \`CancellationToken.None\` ou des CTS isolés étaient utilisés à tort :

### 1. Timeouts des partages MCDF & Housing liés à la connexion
\`McdfShareUpload\`, \`McdfShareDownload\`, \`HousingShareUpload\`, \`HousingShareDownload\` créaient un \`CancellationTokenSource(TimeSpan.FromMinutes(30))\` totalement isolé. Une déconnexion en cours d'upload laissait l'appel SignalR poireauter jusqu'à 30 min avant de timeout côté client.

→ Liaison via \`CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, _connectionCancellationTokenSource.Token)\`. Une perte de connexion interrompt désormais l'opération immédiatement.

### 2. Décompression LZ4 dans FileDownloadManager
Les \`Task.Run\` de décompression et leurs \`gate.WaitAsync\` (sémaphore CPU bound) utilisaient \`CancellationToken.None\`. Si le téléchargement parent était annulé pendant que des chunks attendaient leur tour sur la gate, ils restaient bloqués indéfiniment.

→ Forwarding du \`ct\` de la méthode \`DownloadFilesInternal\` vers le \`Task.Run\` et le \`gate.WaitAsync\`. Les \`Task.WaitAll\` dans les blocs \`finally\` sont laissés en \`CancellationToken.None\` (intentionnel : assure le drainage des tâches en cours pour libérer la sémaphore et nettoyer les fichiers temporaires).