### PR TITLE
fix(reconnect): bootstrap atomique des paires au reconnect

### DIFF
--- a/UmbraSync/WebAPI/SignalR/ApiController.Functions.Callbacks.cs
+++ b/UmbraSync/WebAPI/SignalR/ApiController.Functions.Callbacks.cs
@@ -515,6 +515,18 @@ public partial class ApiController
 
     private void ExecuteSafely(Action act)
     {
+        if (_bootstrapInProgress)
+        {
+            lock (_bootstrapLock)
+            {
+                if (_bootstrapInProgress)
+                {
+                    _pendingBootstrapCallbacks.Enqueue(act);
+                    return;
+                }
+            }
+        }
+
         try
         {
             act();
@@ -522,6 +534,55 @@ public partial class ApiController
         catch (Exception ex)
         {
             Logger.LogCritical(ex, "Error on executing safely");
+        }
+    }
+
+    private void BeginBootstrap()
+    {
+        lock (_bootstrapLock)
+        {
+            _bootstrapInProgress = true;
+            while (_pendingBootstrapCallbacks.TryDequeue(out _)) { }
+        }
+    }
+
+    private void AbortBootstrap()
+    {
+        lock (_bootstrapLock)
+        {
+            while (_pendingBootstrapCallbacks.TryDequeue(out _)) { }
+            _bootstrapInProgress = false;
+        }
+    }
+
+    private void DrainBootstrapCallbacks()
+    {
+        while (_pendingBootstrapCallbacks.TryDequeue(out var act))
+        {
+            try
+            {
+                act();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogCritical(ex, "Error draining bootstrap callback");
+            }
+        }
+
+        lock (_bootstrapLock)
+        {
+            while (_pendingBootstrapCallbacks.TryDequeue(out var act))
+            {
+                try
+                {
+                    act();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogCritical(ex, "Error draining bootstrap callback");
+                }
+            }
+            _bootstrapInProgress = false;
         }
     }
 }

--- a/UmbraSync/WebAPI/SignalR/ApiController.cs
+++ b/UmbraSync/WebAPI/SignalR/ApiController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Globalization;
 using UmbraSync.API.Data;
@@ -42,6 +43,9 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
     private bool _initialized;
     private HubConnection? _mareHub;
     private ServerState _serverState;
+    private readonly Lock _bootstrapLock = new();
+    private volatile bool _bootstrapInProgress;
+    private readonly ConcurrentQueue<Action> _pendingBootstrapCallbacks = new();
 
     public ApiController(ILogger<ApiController> logger, HubFactory hubFactory, DalamudUtilService dalamudUtil,
         PairManager pairManager, ServerConfigurationManager serverManager, MareMediator mediator,
@@ -182,6 +186,8 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
 
                 _mareHub = await _hubFactory.GetOrCreate(token).ConfigureAwait(false);
 
+                BeginBootstrap();
+
                 InitializeApiHooks();
 
                 await _mareHub.StartAsync(token).ConfigureAwait(false);
@@ -237,6 +243,8 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
 
                 await LoadBootstrapPairs().ConfigureAwait(false);
                 _pairManager.ApplyPendingCharacterData();
+
+                DrainBootstrapCallbacks();
 
                 Mediator.Publish(new ConnectedMessage(_connectionDto));
             }
@@ -443,6 +451,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
     private async Task MareHubOnReconnected()
     {
         ServerState = ServerState.Reconnecting;
+        BeginBootstrap();
         try
         {
             InitializeApiHooks();
@@ -455,6 +464,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
             ServerState = ServerState.Connected;
             await LoadBootstrapPairs().ConfigureAwait(false);
             _pairManager.ApplyPendingCharacterData();
+            DrainBootstrapCallbacks();
             Mediator.Publish(new ConnectedMessage(_connectionDto));
         }
         catch (Exception ex)
@@ -491,6 +501,11 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
     private async Task StopConnection(ServerState state)
     {
         ServerState = ServerState.Disconnecting;
+
+        if (_bootstrapInProgress)
+        {
+            AbortBootstrap();
+        }
 
         Logger.LogInformation("Stopping existing connection");
         await _hubFactory.DisposeHubAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Résumé

Élimine la fenêtre de race entre l'application du snapshot initial (\`LoadBootstrapPairs\`) et les callbacks SignalR concurrents qui peuvent fire dès que \`InitializeApiHooks()\` a enregistré les handlers.

### Symptômes observables avant ce patch
Pendant la replay initial (connexion ou reconnexion), pour chaque pair/groupe le client itère séquentiellement :
\`UserGetPairedClients\` → \`AddUserPair\` → \`AddGroup\` → \`AddGroupPair\` → \`MarkPairOnline\`. Sur la même fenêtre, n'importe quel \`Client_UserAddClientPair\`, \`Client_GroupPairJoined\`, \`Client_UserRemoveClientPair\` etc. peut s'exécuter en parallèle :
- **doublons** : un callback ajoute UserA, le snapshot ré-ajoute le même UserA avec un état potentiellement périmé issu de la requête initiale
- **pertes** : l'utilisateur unpair UserB pendant le bootstrap, le snapshot le ré-ajoute juste après
- **UI incohérente** quelques centaines de ms le temps que le bootstrap se termine

### Approche — option B (queue & drain)

Ajout d'une barrière de bootstrap dans \`ApiController\` :

| Élément | Rôle |
|---|---|
| \`_bootstrapInProgress\` (volatile) | Drapeau lu sans lock dans le hot path \`ExecuteSafely\` |
| \`_pendingBootstrapCallbacks\` (\`ConcurrentQueue<Action>\`) | File des callbacks reçus pendant le bootstrap |
| \`_bootstrapLock\` | Sérialise les transitions du drapeau et le drain final |
| \`BeginBootstrap()\` | Pose la barrière + vide les restes d'une tentative précédente |
| \`DrainBootstrapCallbacks()\` | Rejoue les callbacks **dans l'ordre serveur**, puis lève la barrière sous lock |
| \`AbortBootstrap()\` | Vide la queue + lève la barrière sans rejouer (appelé depuis \`StopConnection\` pour couvrir tous les chemins d'erreur) |

### Diff de comportement

| Phase | Avant | Après |
|---|---|---|
| Callback pendant bootstrap | exécuté en parallèle du snapshot → race | enfilé, rejoué après le snapshot |
| Callback hors bootstrap | exécuté immédiatement | exécuté immédiatement (zéro overhead, double-check sans lock) |
| Échec mid-bootstrap | drapeau resté à true (sans dommage car BeginBootstrap nettoie au prochain cycle) | nettoyé via \`AbortBootstrap\` dans \`StopConnection\` |
| Reconnexion | callback racy possible | barrière re-posée dès \`MareHubOnReconnected\` |

### Pourquoi option B vs A (snapshot diff)

A (récupérer un snapshot complet et appliquer un diff atomique) est plus propre à long terme mais demande de refactor \`LoadBootstrapPairs\` et \`PairManager\` (méthodes \`Apply*Atomically\` + comparateur d'état). B réutilise l'infra existante (\`ConcurrentQueue\`, \`Lock\`) et conserve l'ordre serveur — bon ROI pour ce cycle.