### PR TITLE
fix(signalr): KeepAlive client à 2s pour traverser les middleboxes FAI

### DIFF
--- a/UmbraSync/WebAPI/SignalR/HubFactory.cs
+++ b/UmbraSync/WebAPI/SignalR/HubFactory.cs
@@ -204,7 +204,7 @@ public class HubFactory : MediatorSubscriberBase
             })
             .Build();
 
-        _instance.KeepAliveInterval = TimeSpan.FromSeconds(5);
+        _instance.KeepAliveInterval = TimeSpan.FromSeconds(2);
         _instance.ServerTimeout = TimeSpan.FromMinutes(15);
         _instance.HandshakeTimeout = TimeSpan.FromSeconds(60);
 


### PR DESCRIPTION
## Contexte

Session WebSocket est kill par un middlebox du FAI au bout de ~12s d'idle, juste après la fin du bootstrap. Le KeepAlive actuel (5s côté client, 15s côté serveur) génère un ping toutes les 5s mais ce n'est pas suffisant pour empêcher la classification idle par certaines box (Free notamment).

Pattern observé :
\`\`\`
12:46:30 OnConnectedAsync
12:46:30-37 Bootstrap massif (10+ RPC en 7s)
12:46:37 dernier appel (McdfShareGetOwn)
12:46:43 OnDisconnectedAsync (SessionSec:12, ExceptionType:null)
\`\`\`

Côté client (dalamud.log) :
\`\`\`
The remote party closed the WebSocket connection without completing the close handshake.
\`\`\`

## Changement

\`HubFactory.cs:207\` — \`KeepAliveInterval\` passé de **5s** à **2s**.

Le client envoie désormais un ping toutes les 2s (au lieu de 5s) → trafic montant constant qui empêche les middleboxes de classer la conn comme idle.

## Pourquoi pas plus agressif

Pas descendre en dessous de 2s pour éviter de saturer inutilement le bus pour les users sur connexion correcte. 2s est un bon compromis :
- Plus court que la plupart des seuils middleboxes connus (3-5s)
- Charge réseau négligeable : un ping fait quelques bytes
- Pas de surcharge CPU notable

Le \`ServerTimeout\` (15min) et \`HandshakeTimeout\` (60s) restent conservateurs.