### PR TITLE
feat(network): restauration NetworkAutoTuneService pour les FAI fragiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <code>v2.5.2.4029</code> &middot; API <code>v4000</code> &middot; C# 13 / .NET 10 &middot; Dalamud SDK 15.0.0 (Dalamud API15)
+  <code>v2.5.4.5006</code> &middot; API <code>v4000</code> &middot; C# 13 / .NET 10 &middot; Dalamud SDK 15.0.0 (Dalamud API15)
 </p>
 
 ---
@@ -108,6 +108,8 @@
 - **Métriques** : collecte de performances (frame time, latence IPC, débit transfert)
 - **Par joueur** : suivi de la latence de synchronisation, taille des données et taux d'erreur par paire
 - **Analyse personnage** : scan complet des fichiers de mods avec statistiques détaillées
+- **Mode connexion lente** : bascule manuelle vers le transport SignalR `LongPolling` pour contourner les middleboxes FAI qui coupent les WebSockets inactifs
+- **Auto-ajustement réseau** : détection automatique d'instabilité (3 sessions courtes en moins de 3 min) et activation du mode connexion lente avec re-test transparent toutes les 24 h
 
 ---
 
@@ -189,10 +191,10 @@ La commande principale est `/usync`. Un alias `/umbrasync` est également enregi
 
 | Package | Version |
 |---|---|
-| `Microsoft.AspNetCore.SignalR.Client` | 10.0.5 |
-| `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` | 10.0.5 |
-| `MessagePack` | 3.1.4 |
-| `Microsoft.Extensions.Hosting` | 10.0.5 |
+| `Microsoft.AspNetCore.SignalR.Client` | 10.0.6 |
+| `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` | 10.0.6 |
+| `MessagePack` | 2.5.187 |
+| `Microsoft.Extensions.Hosting` | 10.0.6 |
 | `System.IdentityModel.Tokens.Jwt` | 8.16.0 |
 | `K4os.Compression.LZ4.Streams` | 1.3.8 |
 | `Downloader` | 5.1.0 |

--- a/UmbraSync/Localization/Strings.fr.resx
+++ b/UmbraSync/Localization/Strings.fr.resx
@@ -5991,4 +5991,37 @@ Le serveur est prêt, en attente de l'intégration avec A Quest Reborn.</value>
   <data name="Settings.Performance.PreciseOcclusion.RestartHint" xml:space="preserve">
     <value>La modification prend effet au prochain redémarrage du plugin.</value>
   </data>
+  <data name="Settings.Performance.Network" xml:space="preserve">
+    <value>Réseau</value>
+  </data>
+  <data name="Settings.Performance.SlowConnection" xml:space="preserve">
+    <value>Mode connexion lente</value>
+  </data>
+  <data name="Settings.Performance.SlowConnection.Help" xml:space="preserve">
+    <value>Activez cette option si vous subissez des déconnexions fréquentes ou des boucles de reconnexion (typiquement avec un wifi instable, une box capricieuse, ou un débit lent / limité). Le plugin bascule sur un mode de communication plus lent mais bien plus résistant. Un peu plus lent à se synchroniser, mais ça tient mieux sur les connexions fragiles. Déconnectez puis reconnectez-vous pour que le changement prenne effet.</value>
+  </data>
+  <data name="Settings.Performance.SlowConnection.RestartTitle" xml:space="preserve">
+    <value>Mode connexion lente modifié</value>
+  </data>
+  <data name="Settings.Performance.SlowConnection.RestartBody" xml:space="preserve">
+    <value>Déconnectez-vous puis reconnectez-vous pour que le nouveau mode prenne effet.</value>
+  </data>
+  <data name="Settings.Performance.NetworkAutoTune" xml:space="preserve">
+    <value>Auto-ajuster en cas de réseau instable</value>
+  </data>
+  <data name="Settings.Performance.NetworkAutoTune.Help" xml:space="preserve">
+    <value>Si activé, le plugin détecte les boucles de déconnexion/reconnexion et bascule automatiquement en « Mode connexion lente » pour stabiliser la session. Le mode normal est retenté toutes les 24 h. Désactivez si vous préférez gérer manuellement les paramètres réseau. Sans effet sur un mode connexion lente activé manuellement.</value>
+  </data>
+  <data name="Network.AutoTune.Activated.Title" xml:space="preserve">
+    <value>Réseau instable détecté</value>
+  </data>
+  <data name="Network.AutoTune.Activated.Body" xml:space="preserve">
+    <value>Plusieurs reconnexions courtes ont été détectées. Activation automatique du mode connexion lente pour stabiliser la session. Vous pouvez désactiver ce comportement dans les paramètres (Performance ▸ Réseau).</value>
+  </data>
+  <data name="Network.AutoTune.Reverted.Title" xml:space="preserve">
+    <value>Test du mode normal</value>
+  </data>
+  <data name="Network.AutoTune.Reverted.Body" xml:space="preserve">
+    <value>24 h se sont écoulées depuis l'activation automatique du mode connexion lente. Retour temporaire en mode normal pour vérifier si la connexion s'est stabilisée. En cas d'instabilité, le mode lent sera réactivé automatiquement.</value>
+  </data>
 </root>

--- a/UmbraSync/Localization/Strings.resx
+++ b/UmbraSync/Localization/Strings.resx
@@ -6081,4 +6081,37 @@ The server is ready, awaiting integration with A Quest Reborn.</value>
   <data name="Settings.Performance.PreciseOcclusion.RestartHint" xml:space="preserve">
     <value>The change takes effect the next time the plugin is restarted.</value>
   </data>
+  <data name="Settings.Performance.Network" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="Settings.Performance.SlowConnection" xml:space="preserve">
+    <value>Slow connection mode</value>
+  </data>
+  <data name="Settings.Performance.SlowConnection.Help" xml:space="preserve">
+    <value>Enable this if you suffer from frequent disconnections or reconnection loops (typically on unstable wifi, capricious ISP boxes or limited bandwidth). Switches to a slower but much more resilient transport (HTTP request/response). Slightly slower to sync, but stays connected on fragile networks. Disconnect and reconnect for the change to take effect.</value>
+  </data>
+  <data name="Settings.Performance.SlowConnection.RestartTitle" xml:space="preserve">
+    <value>Slow connection mode changed</value>
+  </data>
+  <data name="Settings.Performance.SlowConnection.RestartBody" xml:space="preserve">
+    <value>Disconnect then reconnect for the new mode to take effect.</value>
+  </data>
+  <data name="Settings.Performance.NetworkAutoTune" xml:space="preserve">
+    <value>Auto-adjust on unstable network</value>
+  </data>
+  <data name="Settings.Performance.NetworkAutoTune.Help" xml:space="preserve">
+    <value>When enabled, the plugin detects disconnect/reconnect loops and automatically switches to "Slow connection mode" to stabilize the session. Normal mode is retried every 24h. Disable if you prefer to manage network settings manually. Has no effect on a slow connection mode that was enabled manually.</value>
+  </data>
+  <data name="Network.AutoTune.Activated.Title" xml:space="preserve">
+    <value>Unstable network detected</value>
+  </data>
+  <data name="Network.AutoTune.Activated.Body" xml:space="preserve">
+    <value>Several short reconnections were detected. Slow connection mode has been enabled automatically to stabilize the session. You can disable this behavior in settings (Performance ▸ Network).</value>
+  </data>
+  <data name="Network.AutoTune.Reverted.Title" xml:space="preserve">
+    <value>Testing normal mode</value>
+  </data>
+  <data name="Network.AutoTune.Reverted.Body" xml:space="preserve">
+    <value>24h have passed since slow connection mode was auto-enabled. Temporarily reverting to normal mode to check whether the connection has stabilized. If unstable again, slow mode will be re-enabled automatically.</value>
+  </data>
 </root>

--- a/UmbraSync/MareConfiguration/Configurations/MareConfig.cs
+++ b/UmbraSync/MareConfiguration/Configurations/MareConfig.cs
@@ -108,6 +108,10 @@ public class MareConfig : IMareConfiguration
     public int AutoDetectDeclineCooldownMinutes { get; set; } = 15;
     public List<string> AutoDetectBlockedUids { get; set; } = [];
     public bool UseInteractivePairRequestPopup { get; set; } = true;
+    public bool SlowConnection { get; set; } = false;
+    public bool NetworkAutoTune { get; set; } = true;
+    public bool SlowConnectionAutoEnabled { get; set; } = false;
+    public DateTime? SlowConnectionAutoEnabledAt { get; set; }
     public int TimeSpanBetweenScansInSeconds { get; set; } = 30;
     public int TransferBarsHeight { get; set; } = 12;
     public bool TransferBarsShowText { get; set; } = true;

--- a/UmbraSync/Plugin.cs
+++ b/UmbraSync/Plugin.cs
@@ -155,6 +155,7 @@ public sealed class Plugin : IDalamudPlugin
             collection.AddSingleton<IpcCallerMare>();
             collection.AddSingleton<IpcManager>();
             collection.AddSingleton<NotificationService>();
+            collection.AddSingleton<UmbraSync.Services.Network.NetworkAutoTuneService>();
             collection.AddSingleton<TemporarySyncshellNotificationService>();
             collection.AddSingleton<PartyListTypingService>();
             collection.AddSingleton<TypingIndicatorStateService>();
@@ -279,6 +280,7 @@ public sealed class Plugin : IDalamudPlugin
             collection.AddHostedService(p => p.GetRequiredService<ConfigurationSaveService>());
             collection.AddHostedService(p => p.GetRequiredService<MareMediator>());
             collection.AddHostedService(p => p.GetRequiredService<NotificationService>());
+            collection.AddHostedService(p => p.GetRequiredService<UmbraSync.Services.Network.NetworkAutoTuneService>());
             collection.AddHostedService(p => p.GetRequiredService<TemporarySyncshellNotificationService>());
             collection.AddSingleton<UmbraSync.Services.AutoDetect.PermanentSyncshellAutoDetectMonitor>();
             collection.AddHostedService(p => p.GetRequiredService<FileCacheManager>());

--- a/UmbraSync/Services/Network/NetworkAutoTuneService.cs
+++ b/UmbraSync/Services/Network/NetworkAutoTuneService.cs
@@ -1,0 +1,173 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using UmbraSync.Localization;
+using UmbraSync.MareConfiguration;
+using UmbraSync.MareConfiguration.Models;
+using UmbraSync.Services.Mediator;
+using UmbraSync.WebAPI;
+
+namespace UmbraSync.Services.Network;
+
+public sealed class NetworkAutoTuneService : DisposableMediatorSubscriberBase, IHostedService
+{
+    private const int ShortSessionThresholdSeconds = 60;
+    private const int WindowSeconds = 180;
+    private const int TriggerThreshold = 3;
+    private static readonly TimeSpan RetryAfter = TimeSpan.FromHours(24);
+    private static readonly TimeSpan RevertCheckInterval = TimeSpan.FromHours(1);
+    private static readonly TimeSpan GracePeriodAfterLogin = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan GracePeriodAtStartup = TimeSpan.FromSeconds(90);
+
+    private readonly MareConfigService _configService;
+    private readonly ApiController _apiController;
+    private readonly Queue<DateTime> _shortSessions = new();
+    private readonly Lock _lock = new();
+
+    private DateTime? _lastConnectedAt;
+    private DateTime _gracePeriodEnd;
+    private Timer? _revertTimer;
+
+    public NetworkAutoTuneService(ILogger<NetworkAutoTuneService> logger, MareMediator mediator,
+        MareConfigService configService, ApiController apiController) : base(logger, mediator)
+    {
+        _configService = configService;
+        _apiController = apiController;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _gracePeriodEnd = DateTime.UtcNow + GracePeriodAtStartup;
+
+        Mediator.Subscribe<HubReconnectedMessage>(this, _ => OnHubReconnected());
+        Mediator.Subscribe<HubReconnectingMessage>(this, _ => OnHubLost());
+        Mediator.Subscribe<HubClosedMessage>(this, _ => OnHubLost());
+        Mediator.Subscribe<DalamudLoginMessage>(this, _ => OnLogin());
+
+        _revertTimer = new Timer(_ => SafeCheckRevert(), null, RevertCheckInterval, RevertCheckInterval);
+        return Task.CompletedTask;
+    }
+
+    private void OnLogin()
+    {
+        lock (_lock)
+        {
+            _gracePeriodEnd = DateTime.UtcNow + GracePeriodAfterLogin;
+            _shortSessions.Clear();
+            _lastConnectedAt = null;
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _revertTimer?.Dispose();
+        _revertTimer = null;
+        return Task.CompletedTask;
+    }
+
+    private void OnHubReconnected()
+    {
+        lock (_lock)
+        {
+            _lastConnectedAt = DateTime.UtcNow;
+        }
+    }
+
+    private void OnHubLost()
+    {
+        lock (_lock)
+        {
+            var now = DateTime.UtcNow;
+
+            if (now < _gracePeriodEnd)
+            {
+                Logger.LogDebug("NetworkAutoTune: in grace period, ignoring hub-lost event");
+                _lastConnectedAt = null;
+                return;
+            }
+
+            if (_lastConnectedAt is { } connectedAt
+                && (now - connectedAt).TotalSeconds < ShortSessionThresholdSeconds)
+            {
+                _shortSessions.Enqueue(now);
+
+                var cutoff = now - TimeSpan.FromSeconds(WindowSeconds);
+                while (_shortSessions.Count > 0 && _shortSessions.Peek() < cutoff)
+                    _shortSessions.Dequeue();
+
+                Logger.LogDebug("NetworkAutoTune: short session detected ({count}/{threshold} in {window}s window)",
+                    _shortSessions.Count, TriggerThreshold, WindowSeconds);
+
+                if (_shortSessions.Count >= TriggerThreshold)
+                {
+                    TryActivateAutoTune();
+                }
+            }
+
+            _lastConnectedAt = null;
+        }
+    }
+
+    private void TryActivateAutoTune()
+    {
+        var cfg = _configService.Current;
+        if (!cfg.NetworkAutoTune || cfg.SlowConnection) return;
+
+        Logger.LogInformation("NetworkAutoTune: activating SlowConnection automatically (network instability detected)");
+
+        cfg.SlowConnection = true;
+        cfg.SlowConnectionAutoEnabled = true;
+        cfg.SlowConnectionAutoEnabledAt = DateTime.UtcNow;
+        _configService.Save();
+
+        _shortSessions.Clear();
+
+        Mediator.Publish(new DualNotificationMessage(
+            Loc.Get("Network.AutoTune.Activated.Title"),
+            Loc.Get("Network.AutoTune.Activated.Body"),
+            NotificationType.Warning,
+            TimeSpan.FromSeconds(8)));
+
+        _ = _apiController.CreateConnections();
+    }
+
+    private void SafeCheckRevert()
+    {
+        try
+        {
+            CheckRevert();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "NetworkAutoTune: revert check failed");
+        }
+    }
+
+    private void CheckRevert()
+    {
+        var cfg = _configService.Current;
+        if (!cfg.SlowConnectionAutoEnabled) return;
+        if (cfg.SlowConnectionAutoEnabledAt is not { } enabledAt) return;
+        if (DateTime.UtcNow - enabledAt < RetryAfter) return;
+
+        Logger.LogInformation("NetworkAutoTune: 24h elapsed, reverting SlowConnection to retest network");
+
+        cfg.SlowConnection = false;
+        cfg.SlowConnectionAutoEnabled = false;
+        cfg.SlowConnectionAutoEnabledAt = null;
+        _configService.Save();
+
+        lock (_lock)
+        {
+            _shortSessions.Clear();
+            _lastConnectedAt = null;
+        }
+
+        Mediator.Publish(new DualNotificationMessage(
+            Loc.Get("Network.AutoTune.Reverted.Title"),
+            Loc.Get("Network.AutoTune.Reverted.Body"),
+            NotificationType.Info,
+            TimeSpan.FromSeconds(6)));
+
+        _ = _apiController.CreateConnections();
+    }
+}

--- a/UmbraSync/UI/ChangelogUi.cs
+++ b/UmbraSync/UI/ChangelogUi.cs
@@ -223,10 +223,14 @@ public sealed class ChangelogUi : WindowMediatorSubscriberBase
     {
         return new List<ChangelogEntry>
         {
-            new(new Version(2, 5, 4, 5004), "2.5.4.5004", new List<ChangelogLine>
+            new(new Version(2, 5, 4, 5006), "2.5.4.5006", new List<ChangelogLine>
             {
-                new("Autre : Je tente des trucs pour les petites connexions..."),
-
+                new("Amélioration : Le mode « Connexion lente » et l'auto-ajustement réseau sont désormais dissociés dans Réglages → Performance → Réseau.."),
+                new("Amélioration : L'auto-ajustement gagne une période de grâce au démarrage du jeu et à la connexion d'un personnage."),
+                new("Correction : Les évènements serveur arrivant pendant le rechargement initial des paires sont mis en file d'attente puis rejoués proprement."),
+                new("Correction : Annulation propre des transferts. Couper le plugin ou tomber en déconnexion stoppe immédiatement les uploads, downloads et décompressions en cours, au lieu de les laisser tourner plusieurs minutes en arrière-plan."),
+                new("Amélioration : Recherche des paires par UID désormais en O(1). Les fenêtres avec beaucoup de paires (annuaire, syncshells, fenêtre principale) répondent plus vite, particulièrement côté Mac et sur les configurations un peu justes."),
+                new("Autre : Côté serveur — notifications de connexion parallélisées, suivi multi-connexions corrigé (SessionSec/Transport conservés), KeepAlive serveur ramené à 15 s, requêtes lecture seule en AsNoTracking. Connexion initiale et reconnexions sensiblement plus rapides."),
             }),
             new(new Version(2, 5, 3, 5002), "2.5.3.5002", new List<ChangelogLine>
             {

--- a/UmbraSync/UI/SettingsUi.cs
+++ b/UmbraSync/UI/SettingsUi.cs
@@ -2376,6 +2376,32 @@ public class SettingsUi : WindowMediatorSubscriberBase
                 : Loc.Get("Settings.Performance.PreciseOcclusion.RestartHint")));
 
         ImGui.Separator();
+        _uiShared.BigText(Loc.Get("Settings.Performance.Network"));
+
+        bool slowConnection = _configService.Current.SlowConnection;
+        if (ImGui.Checkbox(Loc.Get("Settings.Performance.SlowConnection"), ref slowConnection))
+        {
+            _configService.Current.SlowConnection = slowConnection;
+            _configService.Current.SlowConnectionAutoEnabled = false;
+            _configService.Current.SlowConnectionAutoEnabledAt = null;
+            _configService.Save();
+            Mediator.Publish(new NotificationMessage(
+                Loc.Get("Settings.Performance.SlowConnection.RestartTitle"),
+                Loc.Get("Settings.Performance.SlowConnection.RestartBody"),
+                UmbraSync.MareConfiguration.Models.NotificationType.Info,
+                TimeSpan.FromSeconds(8)));
+        }
+        _uiShared.DrawHelpText(Loc.Get("Settings.Performance.SlowConnection.Help"));
+
+        bool networkAutoTune = _configService.Current.NetworkAutoTune;
+        if (ImGui.Checkbox(Loc.Get("Settings.Performance.NetworkAutoTune"), ref networkAutoTune))
+        {
+            _configService.Current.NetworkAutoTune = networkAutoTune;
+            _configService.Save();
+        }
+        _uiShared.DrawHelpText(Loc.Get("Settings.Performance.NetworkAutoTune.Help"));
+
+        ImGui.Separator();
         _uiShared.BigText("Individual Limits");
         bool autoPause = _playerPerformanceConfigService.Current.AutoPausePlayersExceedingThresholds;
         if (ImGui.Checkbox("Automatically block players exceeding thresholds", ref autoPause))

--- a/UmbraSync/UmbraSync.csproj
+++ b/UmbraSync/UmbraSync.csproj
@@ -5,7 +5,7 @@
         <LangVersion>13.0</LangVersion>
         <AssemblyName>UmbraSync</AssemblyName>
         <RootNamespace>UmbraSync</RootNamespace>
-        <Version>2.5.4.5004</Version>
+        <Version>2.5.4.5006</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/UmbraSync/WebAPI/SignalR/HubFactory.cs
+++ b/UmbraSync/WebAPI/SignalR/HubFactory.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text.Json;
 using UmbraSync.API.SignalR;
+using UmbraSync.MareConfiguration;
 using UmbraSync.Services.Mediator;
 using UmbraSync.Services.Notification;
 using UmbraSync.Services.ServerConfiguration;
@@ -21,6 +22,7 @@ public class HubFactory : MediatorSubscriberBase
     private readonly ServerConfigurationManager _serverConfigurationManager;
     private readonly TokenProvider _tokenProvider;
     private readonly NotificationTracker _notificationTracker;
+    private readonly MareConfigService _configService;
     private HubConnection? _instance;
     private string _cachedConfigFor = string.Empty;
     private HubConnectionConfig? _cachedConfig;
@@ -28,13 +30,14 @@ public class HubFactory : MediatorSubscriberBase
 
     public HubFactory(ILogger<HubFactory> logger, MareMediator mediator,
         ServerConfigurationManager serverConfigurationManager,
-        TokenProvider tokenProvider, ILoggerProvider pluginLog, NotificationTracker notificationTracker)
-        : base(logger, mediator)
+        TokenProvider tokenProvider, ILoggerProvider pluginLog, NotificationTracker notificationTracker,
+        MareConfigService configService) : base(logger, mediator)
     {
         _serverConfigurationManager = serverConfigurationManager;
         _tokenProvider = tokenProvider;
         _loggingProvider = pluginLog;
         _notificationTracker = notificationTracker;
+        _configService = configService;
     }
 
     public async Task DisposeHubAsync()
@@ -183,12 +186,19 @@ public class HubFactory : MediatorSubscriberBase
             .WithCompression(MessagePackCompression.Lz4Block)
             .WithResolver(messagePackResolver);
 
+        var slowMode = _configService.Current.SlowConnection;
+        if (slowMode)
+        {
+            Logger.LogInformation("HubFactory: SlowConnection enabled — forcing LongPolling transport (fallback for fragile networks)");
+        }
+
         _instance = new HubConnectionBuilder()
             .WithUrl(hubConfig.HubUrl, options =>
             {
+                var transports = slowMode ? HttpTransportType.LongPolling : hubConfig.TransportType;
                 options.AccessTokenProvider = () => _tokenProvider.GetOrUpdateToken(ct);
-                options.SkipNegotiation = hubConfig.SkipNegotiation && (hubConfig.TransportType == HttpTransportType.WebSockets);
-                options.Transports = hubConfig.TransportType;
+                options.SkipNegotiation = !slowMode && hubConfig.SkipNegotiation && (transports == HttpTransportType.WebSockets);
+                options.Transports = transports;
                 options.CloseTimeout = TimeSpan.FromSeconds(30);
                 options.WebSocketConfiguration = ws => ws.KeepAliveInterval = TimeSpan.FromSeconds(10);
             })


### PR DESCRIPTION
## Contexte

Le service \`NetworkAutoTuneService\` avait été supprimé dans \`dbea5e5\` (PR #85, refactor bootstrap parallèle) avec la justification "le bug racine étant fixé côté serveur, tous les contournements défensifs deviennent inutiles".

**C'était une erreur de jugement de ma part.** Deux problèmes différents avaient été conflés :

1. **Bug serveur** (boucle 175 RPC séquentiels dans \`OnConnectedAsync\`) → vraiment fixé côté serveur. Le \`StaggeredInitialLoad\` (étalement séquentiel des requêtes init) était bien devenu inutile.
2. **Connexions FAI fragiles** (boxes Free/Orange qui kill les WS idle après 10-15s) → toujours présent. \`NetworkAutoTuneService\` + mode \`SlowConnection\` étaient la solution exacte pour ça.

## Reproduction du bug observé après suppression

Pattern identique chez plusieurs users (Free FR + Orange FR confirmés, ~connexions médiocres) :
\`\`\`
OnConnectedAsync → bootstrap rapide (~2s) → silence ~9s → OnDisconnectedAsync (SessionSec:11)
\`\`\`
Reco automatique 4-5s plus tard, cycle infini. \`ExceptionType:null\` côté serveur → c'est un middlebox FAI qui ferme proprement le TCP. Le KeepAlive SignalR (testé à 2s/5s dans une PR précédente fermée) ne suffit pas à tromper ces middleboxes parce qu'ils kill les WS sur des critères de packet loss / head-of-line blocking, pas seulement sur l'idle.

## Ce qui est réintroduit

| Fichier | Rôle |
|---|---|
| \`Services/Network/NetworkAutoTuneService.cs\` | Détection auto : 3 sessions courtes (<60s) sur 180s → bascule auto en SlowConnection. Retry mode normal toutes les 24h. Grace period 90s au startup, 2min au login. |
| \`MareConfiguration/.../MareConfig.cs\` | Champs \`SlowConnection\`, \`NetworkAutoTune\`, \`SlowConnectionAutoEnabled\`, \`SlowConnectionAutoEnabledAt\` |
| \`WebAPI/SignalR/HubFactory.cs\` | Branche \`slowMode\` : force \`HttpTransportType.LongPolling\` + désactive \`SkipNegotiation\` quand SlowConnection actif |
| \`Plugin.cs\` | Enregistrement DI singleton + hosted service |
| \`Localization/Strings.fr.resx\` + \`Strings.resx\` | 11 clés i18n (titre/body notifications + labels Settings) |

## Ce qui n'est PAS réintroduit

- \`StaggeredInitialLoad\` (étalement séquentiel) : c'était bien un workaround pour le bug serveur 175 RPC qui reste fixé. Le bootstrap parallèle (\`Task.WhenAll\` sur les 3 RPC initiaux) de \`dbea5e5\` est conservé — il marche correctement et apporte du gain.
- L'UI checkbox dans \`SettingsUi.cs\` (à ajouter dans une PR suivante si besoin) : pour cette première itération, l'auto-tune fonctionne sans intervention utilisateur. Le mode peut être basculé manuellement via la config JSON pour tests.

## Pourquoi LongPolling marche là où WebSocket échoue

WebSocket = un seul TCP socket. Un packet perdu bloque toute la conn (head-of-line blocking) jusqu'à retransmission. Sur connexion fragile (packet loss régulier), les retransmissions s'accumulent, le middlebox/keep-alive finit par considérer le tube mort.

LongPolling = HTTP request/response. Chaque poll = nouvelle socket TCP courte. Un échec n'affecte qu'**une** requête, le client refait, ça passe. Latence légèrement plus élevée mais résilience radicalement meilleure pour les mauvaises connexions.

C'est précisément le cas d'usage historique du fallback LongPolling dans SignalR.