### PR TITLE
perf(bootstrap): rework du chargement initial des paires

### DIFF
--- a/UmbraSync/PlayerData/Pairs/PairManager.cs
+++ b/UmbraSync/PlayerData/Pairs/PairManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using UmbraSync.API.Data;
 using UmbraSync.API.Data.Comparer;
+using UmbraSync.API.Data.Enum;
 using UmbraSync.API.Data.Extensions;
 using UmbraSync.API.Dto.Group;
 using UmbraSync.API.Dto.User;
@@ -46,6 +47,9 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
     private readonly Lock _lazyRecreateLock = new();
     private bool _lazyRecreateScheduled;
     private int _pendingLazyRecreateCount;
+    // Pendant le bootstrap, on skip RecreateLazyDebounced ; ApplyBootstrapSnapshot fait
+    // un seul RecreateLazyImmediate à la fin de l'apply pour livrer un état UI cohérent.
+    private volatile bool _bootstrapInProgress;
     private static readonly TimeSpan GroupReapplyThrottleDelay = TimeSpan.FromMilliseconds(100);
     private const int MaxConcurrentGroupReapplies = 5;
     private readonly ConcurrentQueue<Pair> _pendingGroupReapplies = new();
@@ -159,7 +163,7 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
         }
     }
 
-    public void AddUserPair(UserFullPairDto dto)
+    public void AddUserPair(UserFullPairDto dto, IReadOnlyDictionary<string, GroupFullInfoDto>? groupsByGid = null)
     {
         if (!_allClientPairs.ContainsKey(dto.User))
         {
@@ -170,8 +174,29 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
 
         var pair = _allClientPairs[dto.User];
         var prevPaused = pair.IsPaused;
-        pair.UserPair = new UserPairDto(dto.User, dto.IndividualPairStatus, dto.OwnPermissions, dto.OtherPermissions);
+
+        // pair.UserPair n'est positionné que pour les pairs directs (Bidirectional/OneSided).
+        // Pour un pair purement implicite via syncshell (IndividualPairStatus.None), on laisse UserPair null
+        // sinon IsAlreadyDirectPaired() et la logique IsPaused considéreraient à tort le pair comme direct.
+        if (dto.IndividualPairStatus != IndividualPairStatus.None)
+        {
+            pair.UserPair = new UserPairDto(dto.User, dto.IndividualPairStatus, dto.OwnPermissions, dto.OtherPermissions);
+        }
+
         pair.SetGroups(dto.GIDs);
+
+        // Au bootstrap, le serveur enrichit GroupFullInfoDto.GroupPairUserInfos avec les flags pinned/mod
+        // de chaque syncshell jointe. On peut donc materialiser pair.GroupPair[group] sans GroupsGetUsersInGroup × N.
+        // Les GroupUserPermissions par-membre sont initialisés à NoneSet ; les events runtime les mettent à jour.
+        if (groupsByGid != null)
+        {
+            foreach (var gid in dto.GIDs)
+            {
+                if (!groupsByGid.TryGetValue(gid, out var groupDto)) continue;
+                var pairUserInfo = groupDto.GroupPairUserInfos.TryGetValue(dto.User.UID, out var info) ? info : GroupUserInfo.None;
+                pair.GroupPair[groupDto] = new GroupPairFullInfoDto(groupDto.Group, dto.User, pairUserInfo, GroupUserPermissions.NoneSet);
+            }
+        }
 
         if (!pair.IsPaused)
         {
@@ -183,6 +208,49 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
         }
 
         RecreateLazyDebounced();
+    }
+
+    /// <summary>
+    /// Bootstrap atomique au connect : applique groupes + pairs + presence en une passe
+    /// avec un seul recompute lazy à la fin (au lieu de 50+ debounced).
+    /// L'UI ne voit pas d'état intermédiaire pendant l'apply.
+    ///
+    /// Le buffering des callbacks runtime (Client_UserSendOnline etc. reçus pendant le bootstrap)
+    /// est déjà géré par BeginBootstrap/DrainBootstrapCallbacks au niveau ApiController.
+    /// </summary>
+    public void ApplyBootstrapSnapshot(
+        IReadOnlyList<GroupFullInfoDto> groups,
+        IReadOnlyList<UserFullPairDto> pairs,
+        IReadOnlyList<OnlineUserIdentDto> online)
+    {
+        var groupsByGid = groups.ToDictionary(g => g.Group.GID, StringComparer.Ordinal);
+
+        _bootstrapInProgress = true;
+        try
+        {
+            foreach (var entry in groups)
+            {
+                Logger.LogDebug("Bootstrap group: {entry}", entry);
+                AddGroup(entry);
+            }
+
+            foreach (var userPair in pairs)
+            {
+                Logger.LogDebug("Bootstrap pair: {userPair}", userPair);
+                AddUserPair(userPair, groupsByGid);
+            }
+
+            foreach (var entry in online)
+            {
+                Logger.LogDebug("Bootstrap pair online: {pair}", entry);
+                MarkPairOnline(entry, sendNotif: false);
+            }
+        }
+        finally
+        {
+            _bootstrapInProgress = false;
+            RecreateLazyImmediate();
+        }
     }
 
     public void UpdateIndividualPairStatus(UserIndividualPairStatusDto dto)
@@ -974,6 +1042,12 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
     
     private void RecreateLazyDebounced()
     {
+        if (_bootstrapInProgress)
+        {
+            // Skip pendant le bootstrap : ApplyBootstrapSnapshot fait un RecreateLazyImmediate à la fin.
+            return;
+        }
+
         lock (_lazyRecreateLock)
         {
             _pendingLazyRecreateCount++;

--- a/UmbraSync/PlayerData/Pairs/PairManager.cs
+++ b/UmbraSync/PlayerData/Pairs/PairManager.cs
@@ -192,7 +192,11 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
         {
             foreach (var gid in dto.GIDs)
             {
-                if (!groupsByGid.TryGetValue(gid, out var groupDto)) continue;
+                if (!groupsByGid.TryGetValue(gid, out var groupDto))
+                {
+                    Logger.LogWarning("Bootstrap : GID {gid} listé pour {uid} mais absent de GroupsGetAll (désync RPC)", gid, dto.User.UID);
+                    continue;
+                }
                 var pairUserInfo = groupDto.GroupPairUserInfos.TryGetValue(dto.User.UID, out var info) ? info : GroupUserInfo.None;
                 pair.GroupPair[groupDto] = new GroupPairFullInfoDto(groupDto.Group, dto.User, pairUserInfo, GroupUserPermissions.NoneSet);
             }

--- a/UmbraSync/UI/ChangelogUi.cs
+++ b/UmbraSync/UI/ChangelogUi.cs
@@ -228,7 +228,7 @@ public sealed class ChangelogUi : WindowMediatorSubscriberBase
                 new("Amélioration : Connexion initiale beaucoup plus rapide. Vos paires et syncshells arrivent d'un seul coup au lieu d'apparaître progressivement, et le serveur fait jusqu'à deux tiers de requêtes en moins."),
                 new("Amélioration : Moins de saturation réseau au démarrage. Le client n'envoie plus une rafale de requêtes par syncshell rejointe."),
                 new("Amélioration : Affichage de la liste de paires plus stable au connect."),
-                new("Autre : Refonte interne du protocole de bootstrap (côté client et serveur)."),
+                new("Autre : Refonte interne du protocole démarrage de connexion (côté client et serveur)."),
             }),
             new(new Version(2, 5, 5, 5017), "2.5.5.5017", new List<ChangelogLine>
             {

--- a/UmbraSync/UI/ChangelogUi.cs
+++ b/UmbraSync/UI/ChangelogUi.cs
@@ -223,6 +223,13 @@ public sealed class ChangelogUi : WindowMediatorSubscriberBase
     {
         return new List<ChangelogEntry>
         {
+            new(new Version(2, 5, 6, 5018), "2.5.6.5018", new List<ChangelogLine>
+            {
+                new("Amélioration : Connexion initiale beaucoup plus rapide. Vos paires et syncshells arrivent d'un seul coup au lieu d'apparaître progressivement, et le serveur fait jusqu'à deux tiers de requêtes en moins."),
+                new("Amélioration : Moins de saturation réseau au démarrage. Le client n'envoie plus une rafale de requêtes par syncshell rejointe."),
+                new("Amélioration : Affichage de la liste de paires plus stable au connect."),
+                new("Autre : Refonte interne du protocole de bootstrap (côté client et serveur)."),
+            }),
             new(new Version(2, 5, 5, 5017), "2.5.5.5017", new List<ChangelogLine>
             {
                 new("Correction : Résolution des déconnexions à répétition. Tout est maintenant étalé pour démarrer plus en douceur."),

--- a/UmbraSync/UmbraSync.csproj
+++ b/UmbraSync/UmbraSync.csproj
@@ -5,7 +5,7 @@
         <LangVersion>13.0</LangVersion>
         <AssemblyName>UmbraSync</AssemblyName>
         <RootNamespace>UmbraSync</RootNamespace>
-        <Version>2.5.5.5017</Version>
+        <Version>2.5.6.5018</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/UmbraSync/WebAPI/SignalR/ApiController.cs
+++ b/UmbraSync/WebAPI/SignalR/ApiController.cs
@@ -378,7 +378,11 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
     
     private async Task LoadBootstrapPairs()
     {
-        // 3 appels initiaux en parallèle, puis groupUsers en parallèle dans une 2ème vague.
+        // 3 RPC parallèles, c'est tout. Le serveur retourne :
+        //  - UserGetPairedClients : pairs directs ET pairs syncshell-implicites en une passe (helper GetAllPairInfo).
+        //  - GroupsGetAll : DTO enrichi avec GroupPairUserInfos (flags pinned/mod) + GroupUserCount.
+        //  - UserGetOnlinePairs : présence en ligne via Redis.
+        // Plus de fan-out GroupsGetUsersInGroup × N qui saturait middleboxes/connexion lente au connect.
         var pairedClientsTask = UserGetPairedClients();
         var groupsTask = GroupsGetAll();
         var onlinePairsTask = UserGetOnlinePairs();
@@ -388,40 +392,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
         var pairedClients = await pairedClientsTask.ConfigureAwait(false);
         var allGroups = await groupsTask.ConfigureAwait(false);
         var onlinePairs = await onlinePairsTask.ConfigureAwait(false);
-
-        var groupUsersTasks = allGroups.Select(g => GroupsGetUsersInGroup(g)).ToArray();
-        if (groupUsersTasks.Length > 0)
-        {
-            await Task.WhenAll(groupUsersTasks).ConfigureAwait(false);
-        }
-
-        foreach (var userPair in pairedClients)
-        {
-            Logger.LogDebug("Individual Pair: {userPair}", userPair);
-            _pairManager.AddUserPair(userPair);
-        }
-
-        foreach (var entry in allGroups)
-        {
-            Logger.LogDebug("Group: {entry}", entry);
-            _pairManager.AddGroup(entry);
-        }
-
-        for (int i = 0; i < allGroups.Count; i++)
-        {
-            var users = await groupUsersTasks[i].ConfigureAwait(false);
-            foreach (var user in users)
-            {
-                Logger.LogDebug("Group Pair: {user}", user);
-                _pairManager.AddGroupPair(user, isInitialLoad: true);
-            }
-        }
-
-        foreach (var entry in onlinePairs)
-        {
-            Logger.LogDebug("Pair online: {pair}", entry);
-            _pairManager.MarkPairOnline(entry, sendNotif: false);
-        }
+        _pairManager.ApplyBootstrapSnapshot(allGroups, pairedClients, onlinePairs);
     }
 
     private void MareHubOnClosed(Exception? arg)


### PR DESCRIPTION
## Résumé
Refonte du protocole de bootstrap au connect : passe de 9 RPC (3 + N syncshells) à 3 RPC, et de ~19 queries DB à ~6 côté serveur.

## Changements
- **API** : `GroupFullInfoDto` enrichi avec `GroupPairUserInfos` (UID → flags pinned/mod) et `GroupUserCount`.
- **Serveur** : nouveau helper `GetAllPairInfo(uid)` qui unifie pairs directs + pairs implicites via syncshell en une passe DB. `UserGetPairedClients` et `GroupsGetAll` refactorés pour utiliser ce       
  pattern.
- **Client** : `LoadBootstrapPairs` réduit à 3 RPC parallèles. Suppression du fan-out `GroupsGetUsersInGroup × N`. Nouvelle `PairManager.ApplyBootstrapSnapshot` qui apply atomiquement groupes + paires +
  presence avec un seul recompute lazy à la fin. `AddUserPair(UserFullPairDto)` gère correctement les paires purement syncshell (`IndividualPairStatus.None`).    

## Motivation

Adresse les déconnexions WebSocket observées sur connexions instables pendant le bootstrap (stack pointant vers `GroupsGetUsersInGroup` dans `MareHubOnReconnected`), ainsi que les listes de syncshells
partiellement chargées.