### PR TITLE
Release 2.5.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 ### Syncshells (groupes)
 
 - **Création** : syncshells permanentes ou temporaires (avec date d'expiration)
-- **Administration** : gestion des membres (ban, retrait, permissions), transfert de propriété, changement de mot de passe
+- **Administration** : gestion des membres (ban, retrait, permissions), transfert de propriété, changement de mot de passe, renommage de la syncshell
 - **Invitations temporaires** : génération d'invitations à usage unique
 - **Rôles** : Owner, Moderator, Member avec permissions granulaires
 - **Collection Penumbra** : liaison d'une collection Penumbra spécifique par Syncshell

--- a/UmbraSync/Localization/Strings.fr.resx
+++ b/UmbraSync/Localization/Strings.fr.resx
@@ -3635,6 +3635,12 @@ Note : Les armes ne s'afficheront pas correctement sauf si vous utilisez le m&#x
   <data name="SyncshellAdmin.Owner.RenameFailed" xml:space="preserve">
     <value>Échec du renommage : ce nom est déjà utilisé ou indisponible.</value>
   </data>
+  <data name="SyncshellAdmin.Owner.RenameSuccessTitle" xml:space="preserve">
+    <value>Syncshell renommée</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.RenameSuccessMessage" xml:space="preserve">
+    <value>La syncshell s'appelle désormais « {0} ».</value>
+  </data>
   <data name="SyncshellAdmin.Permissions.Animation" xml:space="preserve">
     <value />
   </data>

--- a/UmbraSync/Localization/Strings.fr.resx
+++ b/UmbraSync/Localization/Strings.fr.resx
@@ -3620,6 +3620,21 @@ Note : Les armes ne s'afficheront pas correctement sauf si vous utilisez le m&#x
   <data name="SyncshellAdmin.Owner.PasswordPlaceholder" xml:space="preserve">
     <value />
   </data>
+  <data name="SyncshellAdmin.Owner.NewAlias" xml:space="preserve">
+    <value>Nouveau nom</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.AliasPlaceholder" xml:space="preserve">
+    <value>Nom de la syncshell (max 50)</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.Rename" xml:space="preserve">
+    <value>Renommer</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.RenameTooltip" xml:space="preserve">
+    <value>Renomme la syncshell. Le nom doit être unique et disponible.</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.RenameFailed" xml:space="preserve">
+    <value>Échec du renommage : ce nom est déjà utilisé ou indisponible.</value>
+  </data>
   <data name="SyncshellAdmin.Permissions.Animation" xml:space="preserve">
     <value />
   </data>

--- a/UmbraSync/Localization/Strings.resx
+++ b/UmbraSync/Localization/Strings.resx
@@ -3836,6 +3836,12 @@ Note: Weapons will not be displayed correctly unless using the same job as the s
   <data name="SyncshellAdmin.Owner.RenameFailed" xml:space="preserve">
     <value>Rename failed: this name is already in use or unavailable.</value>
   </data>
+  <data name="SyncshellAdmin.Owner.RenameSuccessTitle" xml:space="preserve">
+    <value>Syncshell renamed</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.RenameSuccessMessage" xml:space="preserve">
+    <value>The syncshell is now named "{0}".</value>
+  </data>
   <data name="SyncshellAdmin.Permissions.Animation" xml:space="preserve">
     <value>Animation Sync</value>
   </data>

--- a/UmbraSync/Localization/Strings.resx
+++ b/UmbraSync/Localization/Strings.resx
@@ -3821,6 +3821,21 @@ Note: Weapons will not be displayed correctly unless using the same job as the s
   <data name="SyncshellAdmin.Owner.PasswordPlaceholder" xml:space="preserve">
     <value>Min 10 characters</value>
   </data>
+  <data name="SyncshellAdmin.Owner.NewAlias" xml:space="preserve">
+    <value>New Name</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.AliasPlaceholder" xml:space="preserve">
+    <value>Syncshell name (max 50)</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.Rename" xml:space="preserve">
+    <value>Rename</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.RenameTooltip" xml:space="preserve">
+    <value>Rename the syncshell. The name must be unique and available.</value>
+  </data>
+  <data name="SyncshellAdmin.Owner.RenameFailed" xml:space="preserve">
+    <value>Rename failed: this name is already in use or unavailable.</value>
+  </data>
   <data name="SyncshellAdmin.Permissions.Animation" xml:space="preserve">
     <value>Animation Sync</value>
   </data>

--- a/UmbraSync/PlayerData/Pairs/PairManager.cs
+++ b/UmbraSync/PlayerData/Pairs/PairManager.cs
@@ -80,7 +80,10 @@ public sealed class PairManager : DisposableMediatorSubscriberBase
     public List<Pair> DirectPairs => _directPairsInternal.Value;
 
     public Dictionary<GroupFullInfoDto, List<Pair>> GroupPairs => _groupPairsInternal.Value;
-    public Dictionary<GroupData, GroupFullInfoDto> Groups => _allGroups.ToDictionary(k => k.Key, k => k.Value);
+    // Conserve la comparaison par GID (GroupDataComparer) : sinon un renommage de syncshell change
+    // l'égalité du record GroupData (qui inclut l'Alias) et casse les lookups Groups[group] alors
+    // que l'entrée existe toujours sous le même GID.
+    public Dictionary<GroupData, GroupFullInfoDto> Groups => _allGroups.ToDictionary(k => k.Key, k => k.Value, GroupDataComparer.Instance);
     public Pair? LastAddedUser { get; internal set; }
 
     public void AddGroup(GroupFullInfoDto dto)

--- a/UmbraSync/UI/ChangelogUi.cs
+++ b/UmbraSync/UI/ChangelogUi.cs
@@ -342,12 +342,13 @@ public sealed class ChangelogUi : WindowMediatorSubscriberBase
     {
         return new List<ChangelogEntry>
         {
-            new(new Version(2, 5, 9, 5025), "2.5.9.5025", new List<ChangelogLine>
+            new(new Version(2, 5, 9, 6002), "2.5.9.6002", new List<ChangelogLine>
             {
+                new("Nouveauté : Les propriétaires d'une syncshell peuvent désormais la renommer depuis le panneau d'administration (onglet Owner Settings)."),
+                new("Nouveauté : Option « Coordonner les redraws Penumbra » dans Réglages → Transferts."),
                 new("Correction : Crash violent à l'entrée de certains housings partagés. Les chemins reçus sont désormais filtrés pour ne plus pouvoir rediriger d'assets critiques."),
                 new("Amélioration : Charge GPU étalée à l'application des paires. Réduit les crashs sur certains drivers, notamment AMD RX 9060 / 9070."),
                 new("Amélioration : Réglages GPU automatiquement adaptés sur cartes AMD (occlusion en mode raycast, applications espacées) pour limiter les crashs de driver. Ajustable manuellement dans Réglages."),
-                new("Nouveauté : Option « Coordonner les redraws Penumbra » dans Réglages → Transferts."),
                 new("Amélioration : « Paires simultanées max » accepte désormais 1 (sérialisation totale) ; défaut abaissé de 10 à 3. Le toggle « Activer le traitement parallèle » est retiré (redondant)."),
                 new("Autre : Refonte interne du pipeline d'application (téléchargement, Penumbra et personnalisation séparés)."),
             }),

--- a/UmbraSync/UI/SyncshellAdminUI.cs
+++ b/UmbraSync/UI/SyncshellAdminUI.cs
@@ -37,6 +37,8 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
     private int _multiInvites;
     private string _newPassword;
     private bool _pwChangeSuccess;
+    private string _newAlias = string.Empty;
+    private bool _aliasChangeSuccess = true;
     private Task<int>? _pruneTestTask;
     private Task<int>? _pruneTask;
     private int _pruneDays = 14;
@@ -118,6 +120,8 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
         _newPassword = string.Empty;
         _multiInvites = 30;
         _pwChangeSuccess = true;
+        _newAlias = groupFullInfo.GroupAlias ?? string.Empty;
+        _aliasChangeSuccess = true;
         _autoDetectVisible = groupFullInfo.AutoDetectVisible;
         _autoDetectDesiredVisibility = _autoDetectVisible;
         _autoDetectPasswordDisabled = groupFullInfo.PasswordTemporarilyDisabled;
@@ -594,6 +598,35 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
                 var ownerTab = ImRaii.TabItem(Loc.Get("SyncshellAdmin.Tab.Owner"));
                 if (ownerTab)
                 {
+                    ImGui.AlignTextToFramePadding();
+                    ImGui.TextUnformatted(Loc.Get("SyncshellAdmin.Owner.NewAlias"));
+                    var renameButtonSize = _uiSharedService.GetIconTextButtonSize(FontAwesomeIcon.Pen, Loc.Get("SyncshellAdmin.Owner.Rename"));
+                    var renameLabelSize = ImGui.CalcTextSize(Loc.Get("SyncshellAdmin.Owner.NewAlias")).X;
+                    var renameSpacing = ImGui.GetStyle().ItemSpacing.X;
+                    var renameWidth = ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X;
+
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(renameWidth - renameButtonSize - renameLabelSize - renameSpacing * 2);
+                    ImGui.InputTextWithHint("##changealias", Loc.Get("SyncshellAdmin.Owner.AliasPlaceholder"), ref _newAlias, 50);
+                    ImGui.SameLine();
+                    var trimmedAlias = _newAlias.Trim();
+                    using (ImRaii.Disabled(string.IsNullOrWhiteSpace(trimmedAlias)
+                        || string.Equals(trimmedAlias, GroupFullInfo.GroupAlias, StringComparison.Ordinal)))
+                    {
+                        if (_uiSharedService.IconTextButton(FontAwesomeIcon.Pen, Loc.Get("SyncshellAdmin.Owner.Rename")))
+                        {
+                            _aliasChangeSuccess = _apiController.GroupChangeAlias(new GroupAliasDto(GroupFullInfo.Group, trimmedAlias)).Result;
+                        }
+                    }
+                    UiSharedService.AttachToolTip(Loc.Get("SyncshellAdmin.Owner.RenameTooltip"));
+
+                    if (!_aliasChangeSuccess)
+                    {
+                        UiSharedService.ColorTextWrapped(Loc.Get("SyncshellAdmin.Owner.RenameFailed"), ImGuiColors.DalamudYellow);
+                    }
+
+                    ImGui.Separator();
+
                     ImGui.AlignTextToFramePadding();
                     ImGui.TextUnformatted(Loc.Get("SyncshellAdmin.Owner.NewPassword"));
                     var availableWidth = ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X;

--- a/UmbraSync/UI/SyncshellAdminUI.cs
+++ b/UmbraSync/UI/SyncshellAdminUI.cs
@@ -37,8 +37,8 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
     private int _multiInvites;
     private string _newPassword;
     private bool _pwChangeSuccess;
-    private string _newAlias = string.Empty;
-    private bool _aliasChangeSuccess = true;
+    private string _newAlias;
+    private bool _aliasChangeSuccess;
     private Task<int>? _pruneTestTask;
     private Task<int>? _pruneTask;
     private int _pruneDays = 14;
@@ -616,6 +616,13 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
                         if (_uiSharedService.IconTextButton(FontAwesomeIcon.Pen, Loc.Get("SyncshellAdmin.Owner.Rename")))
                         {
                             _aliasChangeSuccess = _apiController.GroupChangeAlias(new GroupAliasDto(GroupFullInfo.Group, trimmedAlias)).Result;
+                            if (_aliasChangeSuccess)
+                            {
+                                Mediator.Publish(new NotificationMessage(
+                                    Loc.Get("SyncshellAdmin.Owner.RenameSuccessTitle"),
+                                    string.Format(CultureInfo.CurrentCulture, Loc.Get("SyncshellAdmin.Owner.RenameSuccessMessage"), trimmedAlias),
+                                    NotificationType.Success, TimeSpan.FromSeconds(5)));
+                            }
                         }
                     }
                     UiSharedService.AttachToolTip(Loc.Get("SyncshellAdmin.Owner.RenameTooltip"));

--- a/UmbraSync/UmbraSync.csproj
+++ b/UmbraSync/UmbraSync.csproj
@@ -5,7 +5,7 @@
         <LangVersion>13.0</LangVersion>
         <AssemblyName>UmbraSync</AssemblyName>
         <RootNamespace>UmbraSync</RootNamespace>
-        <Version>2.5.9.5025</Version>
+        <Version>2.5.9.6002</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/UmbraSync/WebAPI/SignalR/ApiController.Functions.Groups.cs
+++ b/UmbraSync/WebAPI/SignalR/ApiController.Functions.Groups.cs
@@ -36,6 +36,12 @@ public partial class ApiController
         return await _mareHub!.InvokeAsync<bool>(nameof(GroupChangePassword), groupPassword).ConfigureAwait(false);
     }
 
+    public async Task<bool> GroupChangeAlias(GroupAliasDto groupAlias)
+    {
+        CheckConnection();
+        return await _mareHub!.InvokeAsync<bool>(nameof(GroupChangeAlias), groupAlias).ConfigureAwait(false);
+    }
+
     public async Task GroupClear(GroupDto group)
     {
         CheckConnection();


### PR DESCRIPTION
  ## Release 2.5.9

  Cette version regroupe des correctifs de stabilité (crashs GPU et housing) et une nouvelle fonctionnalité d'administration des syncshells.

  ### 🩹 Stabilité GPU
  - **Étalement de la pression GPU à l'application des paires** : le pipeline d'application est désormais découpé (téléchargement / application Penumbra / personnalisation). Les téléchargements tournent en parallèle libre, seule l'étape Penumbra (allocation de ressources D3D11) est sérialisée. Réduit fortement les crashs de driver sur configurations sensibles.
  - **Coordination des redraws Penumbra** : nouvelle option (Réglages → Transferts) qui sérialise les redraws et impose un intervalle minimum configurable, pour lisser les bursts qui faisaient planter certains drivers.
  - **Réglages conservateurs automatiques sur cartes AMD** : détection du GPU au lancement ; sur AMD (Windows), application unique de réglages prudents (occlusion en raycast, applications espacées). Ajustable manuellement, jamais ré-imposé ensuite.
  - **« Paires simultanées max »** accepte désormais la valeur 1 (sérialisation totale) ; défaut abaissé de 10 à 3. Le toggle « Activer le traitement parallèle » est retiré (redondant) migration de config automatique.

  ### 🏠 Housing
  - **Correctif crash housing partagé (#98)** : les chemins reçus dans un partage MCDF housing sont désormais validés (whitelist housing stricte) côté visiteur et côté propriétaire, empêchant un partage de rediriger des assets critiques du jeu, ce qui provoquait un crash violent et une fausse détection de corruption des fichiers.

  ### 👥 Syncshells
  - **Renommage de syncshell** : les propriétaires peuvent renommer leur syncshell depuis le panneau d'administration. Le nom doit être disponible (vérification d'unicité côté serveur) et le changement est propagé en temps réel à tous les membres. Notification de confirmation à la clé.

  ### 🔧 Interne
  - Refonte du pipeline d'application des paires.
  - Correctif d'un crash d'affichage du panneau d'admin après renommage (clé de dictionnaire basée sur le GID).
  - Alignement client/serveur de l'API (DTO `GroupAliasDto`, RPC `GroupChangeAlias`).

  ### ⚠️ Note Mac (XIV on Mac / DXMT)
  Après cette mise à jour, **redémarrez le jeu** plutôt que de recharger le plugin à chaud : le rechargement à chaud d'un plugin natif est instable sous Wine et peut provoquer un crash.